### PR TITLE
build: Resolve cargo target dir via scripts/cargo-target-dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-RUNNER ?= $(CURDIR)/target/debug/chimera run
+CARGO_TARGET_DIR := $(shell $(CURDIR)/scripts/cargo-target-dir)
+RUNNER ?= $(CARGO_TARGET_DIR)/debug/chimera run
 
 build:
 	cargo build --quiet

--- a/scripts/cargo-target-dir
+++ b/scripts/cargo-target-dir
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Print the directory cargo uses for build artefacts."""
+
+import json
+import subprocess
+import sys
+
+result = subprocess.run(
+    ["cargo", "metadata", "--format-version", "1", "--no-deps", "--offline"],
+    capture_output=True,
+    text=True,
+)
+if result.returncode != 0:
+    sys.exit(result.stderr.strip() or "cargo metadata failed")
+print(json.loads(result.stdout)["target_directory"])


### PR DESCRIPTION
The Makefile hard-coded `$(CURDIR)/target` as the runner path, which
breaks when CARGO_TARGET_DIR points elsewhere (e.g. a shared target
directory). Query `cargo metadata` through scripts/cargo-target-dir so
conformance tests find the actual chimera binary.
