### PR TITLE
runtime: Stop clobbering the guest red zone on branches and transitions

### DIFF
--- a/runtime/arch/x86/trampoline.S
+++ b/runtime/arch/x86/trampoline.S
@@ -38,14 +38,14 @@ dispatch:
     mov eax, 0xe7
     xor edx, edx
     xrstor64 [rdi + {TS_FPSTATE}]
-    // Load guest GPRs from *ctx (rdi). rdi itself is loaded last because we
-    // still need it as the base register.
+    // Load guest GPRs from *ctx (rdi). rdi and rsp are loaded last: rdi is
+    // still needed as the base register, and rsp must stay on Chimera's stack
+    // until after the rflags restore below.
     mov rbx, [rdi + {TS_RBX}]
     mov rcx, [rdi + {TS_RCX}]
     mov rdx, [rdi + {TS_RDX}]
     mov rsi, [rdi + {TS_RSI}]
     mov rbp, [rdi + {TS_RBP}]
-    mov rsp, [rdi + {TS_RSP}]   // switch to the guest stack
     mov r8,  [rdi + {TS_R8}]
     mov r9,  [rdi + {TS_R9}]
     mov r10, [rdi + {TS_R10}]
@@ -54,10 +54,15 @@ dispatch:
     mov r13, [rdi + {TS_R13}]
     mov r14, [rdi + {TS_R14}]
     mov r15, [rdi + {TS_R15}]
-    // rflags: push then popfq uses the guest stack briefly.
+    // Restore rflags via push/popfq while rsp is still Chimera's stack. Doing
+    // this after switching to the guest stack would write [guest_rsp-8] and
+    // clobber the guest's red zone (the 128 bytes below rsp the System V ABI
+    // reserves for leaf functions).
     push qword ptr [rdi + {TS_RFLAGS}]
     popfq
-    // rax and rdi loaded last.
+    // Now switch to the guest stack and load the last registers. None of these
+    // touch flags, so the rflags just restored survive to the jump.
+    mov rsp, [rdi + {TS_RSP}]
     mov rax, [rdi + {TS_RAX}]
     mov rdi, [rdi + {TS_RDI}]
     // Jump to host_pc, which we stashed in TS_HOST_PC.
@@ -88,8 +93,12 @@ exit_block:
     mov gs:[{TS_R13}], r13
     mov gs:[{TS_R14}], r14
     mov gs:[{TS_R15}], r15
-    // Capture the guest's rflags before the XSAVE mask setup below: `xor
-    // edx, edx` clobbers flags, so this must happen first.
+    // Switch to Chimera's stack before capturing rflags: a pushfq on the guest
+    // stack would write [guest_rsp-8] and clobber the guest's red zone. The
+    // guest rsp is already saved in TS_RSP, and the moves above leave flags
+    // (still the guest's) untouched. Capturing rflags must also precede the
+    // XSAVE mask setup, whose `xor edx, edx` clobbers flags.
+    mov rsp, gs:[{TS_CHIMERA_RSP}]
     pushfq
     pop rax
     mov gs:[{TS_RFLAGS}], rax
@@ -102,7 +111,6 @@ exit_block:
     // Restore Chimera's FS base so Rust TLS works again.
     mov rax, gs:[{TS_CHIMERA_FS}]
     wrfsbase rax
-    mov rsp, gs:[{TS_CHIMERA_RSP}]
     pop r15
     pop r14
     pop r13

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -336,36 +336,41 @@ fn extract_memory_operand(t: &Instruction) -> MemoryOperand {
     )
 }
 
-/// For a conditional branch, materialize `taken` into `rbx` and `fallthrough`
-/// into `rax`, then `cmovcc rax, rbx` to pick the right one based on the
-/// guest's flags. The flags are preserved up to the `cmov` because every
-/// instruction we emit before it (`mov` to memory, `movabs reg, imm64`)
-/// leaves flags untouched.
+/// For a conditional branch, select between `taken` and `fallthrough` with a
+/// `cmov`, without ever touching the guest stack. A `push`/`pop` here would
+/// write `[rsp-8]` and clobber the guest's red zone — the 128 bytes below
+/// `rsp` that the System V ABI reserves for a leaf function's own use.
+///
+/// Instead, `taken` is stashed in the context's rbx slot (`gs:[8]`) and the
+/// `cmov` reads it straight from memory. The guest's rbx *register* is never
+/// touched, so it stays live; `exit_block` then saves that live rbx over the
+/// slot on the way out, overwriting the scratch value. The flags set by the
+/// block's compare survive up to the `cmov` because every instruction emitted
+/// here (`mov` to memory, `movabs reg, imm64`) leaves flags untouched.
 fn emit_cond_select(
     instrs: &mut Vec<Instruction>,
     jcc_code: Code,
     taken: u64,
     fallthrough: u64,
 ) -> Result<(), Error> {
-    // Use rbx as scratch around a cmov. The original rbx is preserved by
-    // push/pop on the guest stack — saving it to a `gs:[]` slot would conflict
-    // with `exit_trampoline`, which itself writes the *current* rbx into
-    // `gs:[8]` and would lose the original.
+    // gs:[8] is the rbx slot; see the `gs_qword(0)` rax slot in `emit_save_rax`.
+    const RBX_SLOT: i64 = 8;
     let cmov = jcc_to_cmov(jcc_code)?;
     emit_save_rax(instrs)?;
-    instrs.push(mkinstr(Instruction::with1(Code::Push_r64, Register::RBX))?);
-    emit_load_rax_imm(instrs, fallthrough)?;
+    // gs:[rbx] <- taken, staged through rax (there is no `mov m64, imm64`).
+    emit_load_rax_imm(instrs, taken)?;
     instrs.push(mkinstr(Instruction::with2(
-        Code::Mov_r64_imm64,
-        Register::RBX,
-        taken,
+        Code::Mov_rm64_r64,
+        gs_qword(RBX_SLOT),
+        Register::RAX,
     ))?);
+    // rax <- fallthrough, then pull in `taken` from gs:[rbx] if the condition holds.
+    emit_load_rax_imm(instrs, fallthrough)?;
     instrs.push(mkinstr(Instruction::with2(
         cmov,
         Register::RAX,
-        Register::RBX,
+        gs_qword(RBX_SLOT),
     ))?);
-    instrs.push(mkinstr(Instruction::with1(Code::Pop_r64, Register::RBX))?);
     Ok(())
 }
 

--- a/testing/conformance/abi/red-zone.c
+++ b/testing/conformance/abi/red-zone.c
@@ -1,0 +1,84 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// A translator rewrites every block terminator into a stub that computes the
+// next guest PC. Those stubs must not write below the guest's stack pointer.
+// On x86-64 the System V ABI reserves the 128 bytes below rsp -- the "red
+// zone" -- for a leaf function's own use, so a guest may keep live data there
+// without adjusting rsp; clobbering it corrupts the guest. A translator that
+// brackets a conditional branch with a scratch `push`/`pop` on the guest
+// stack writes [rsp-8] and destroys whatever the guest parked there.
+//
+// The test fills the red zone with a sentinel, executes a conditional branch
+// in each direction, then reads the bytes back -- all in one asm block so the
+// compiler never spills into the red zone between the writes and the reads.
+// The read-back is branch-free (xor/or into an accumulator) so the only block
+// terminators between the fill and the check are the branches under test.
+
+#include <stdint.h>
+
+#if defined(__x86_64__) && defined(__linux__)
+
+int main(void) {
+    uint64_t acc;
+    asm volatile(
+        "movabs $0x5eed1e55c0ffee11, %%r10\n\t"
+        // Seed several slots across the 128-byte red zone.
+        "mov %%r10,  -8(%%rsp)\n\t"
+        "mov %%r10, -16(%%rsp)\n\t"
+        "mov %%r10, -64(%%rsp)\n\t"
+        "mov %%r10, -128(%%rsp)\n\t"
+        // A conditional branch that is NOT taken (ZF=1, so jnz falls through),
+        // then one that IS taken. Both are block terminators.
+        "xor %%ecx, %%ecx\n\t"
+        "test %%ecx, %%ecx\n\t"
+        "jnz 8f\n\t"
+        "jz 1f\n\t"
+        "8:\n\t"
+        "ud2\n\t"                       // unreachable
+        "1:\n\t"
+        // acc = OR of (slot ^ sentinel) over every slot: zero iff all intact.
+        "mov  -8(%%rsp), %%rdx\n\t" "xor %%r10, %%rdx\n\t" "mov %%rdx, %[acc]\n\t"
+        "mov -16(%%rsp), %%rdx\n\t" "xor %%r10, %%rdx\n\t" "or  %%rdx, %[acc]\n\t"
+        "mov -64(%%rsp), %%rdx\n\t" "xor %%r10, %%rdx\n\t" "or  %%rdx, %[acc]\n\t"
+        "mov -128(%%rsp), %%rdx\n\t" "xor %%r10, %%rdx\n\t" "or  %%rdx, %[acc]\n\t"
+        : [acc] "=r"(acc)
+        :
+        : "rcx", "rdx", "r10", "cc", "memory");
+
+    return acc != 0; // 0 = red zone intact, 1 = a terminator clobbered it
+}
+
+#elif defined(__aarch64__) && defined(__APPLE__)
+
+// AAPCS64 defines no red zone, so this is not about preserving ABI-reserved
+// scratch -- but the same invariant holds: a translator must not write below
+// the guest's sp when it rewrites a branch, since a guest may park sp one word
+// above a guard page. Stash a sentinel below sp, branch in each direction, and
+// confirm it survives.
+int main(void) {
+    uint64_t acc = 0;
+    asm volatile(
+        "movz x10, #0xee11\n\t"
+        "movk x10, #0xc0ff, lsl #16\n\t"
+        "movk x10, #0x1e55, lsl #32\n\t"
+        "movk x10, #0x5eed, lsl #48\n\t"
+        "stur x10, [sp, #-8]\n\t"
+        "stur x10, [sp, #-64]\n\t"
+        "cmp xzr, xzr\n\t"              // Z=1
+        "b.ne 8f\n\t"                   // not taken
+        "b.eq 1f\n\t"                   // taken
+        "8:\n\t"
+        "brk #0\n\t"                    // unreachable
+        "1:\n\t"
+        "ldur x11, [sp, #-8]\n\t"  "eor x11, x11, x10\n\t" "orr %[acc], %[acc], x11\n\t"
+        "ldur x11, [sp, #-64]\n\t" "eor x11, x11, x10\n\t" "orr %[acc], %[acc], x11\n\t"
+        : [acc] "+r"(acc)
+        :
+        : "x10", "x11", "cc", "memory");
+
+    return acc != 0; // 0 = nothing written below sp, 1 = a terminator wrote there
+}
+
+#else
+#error "unsupported host for red-zone test"
+#endif


### PR DESCRIPTION
Three sites wrote below the guest's rsp, corrupting the System V red zone
(the 128 bytes a leaf function may use without adjusting rsp):

  - The conditional-branch terminator bracketed its cmov scratch with
    push/pop rbx on the guest stack, writing [rsp-8].
  - `dispatch` restored guest rflags with push/popfq after switching rsp to
    the guest stack, writing [rsp-8] on every block entry.
  - `exit_block` captured guest rflags with pushfq/pop while rsp still
    pointed at the guest stack, writing [rsp-8] on every block exit.

A guest leaf function with live data in its red zone across any of these
saw it silently corrupted. The syscall path already dodged this by doing
its pushfq on Chimera's stack; the same trick fixes the entry/exit paths.

Make the conditional-branch terminator select with a memory-operand cmov
that reads `taken` from the context's rbx slot (exit_block re-saves the live
rbx over it), so it never touches the guest stack. Do the rflags push/popfq
in dispatch and exit_block on Chimera's stack instead of the guest's.

Add testing/conformance/abi/red-zone.c: fill the red zone, take a
conditional branch in each direction, and verify the bytes survive.
