### PR TITLE
runtime: Read indirect-call target before pushing return address

### DIFF
--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -15,6 +15,11 @@ use crate::Error;
 const CACHE_SIZE: usize = 16 * 1024 * 1024;
 const MAX_BLOCK_GUEST_BYTES: usize = 4096;
 
+/// `gs:[]` displacement of the guest's rbx slot (`regs[1]`). Terminators that
+/// need a scratch memory slot borrow it: `exit_block` re-saves the live rbx
+/// over the slot on the way out, so the guest's rbx register is preserved.
+const RBX_SLOT: i64 = 8;
+
 /// A bump-allocated RWX region into which `translate()` emits blocks.
 pub struct CodeCache {
     base: *mut u8,
@@ -218,18 +223,25 @@ fn emit_terminator(
             emit_load_rax_from_op0(instrs, t)?;
         }
         FlowControl::IndirectCall => {
-            // Reading the operand can use rax (if op0 is rax) or other regs.
-            // Push the return address first; then load the target.
+            // Read the target with the *original* rsp, before pushing the
+            // return address: hardware computes `CALL m`'s target, then
+            // pushes. Pushing first would evaluate an rsp-relative operand
+            // (e.g. `call [rsp+0x58]`) against the post-push rsp, reading 8
+            // bytes off. rax still holds the guest's rax at this point, so an
+            // operand that uses rax (e.g. `call [rax+8]`) also reads correctly.
             emit_save_rax(instrs)?;
+            emit_load_rax_from_op0(instrs, t)?;
+            // Stash the target in the rbx slot, push the return address, then
+            // reload the target. The rbx register is untouched, so the guest's
+            // rbx survives via exit_block's save.
+            instrs.push(mkinstr(Instruction::with2(
+                Code::Mov_rm64_r64,
+                gs_qword(RBX_SLOT),
+                Register::RAX,
+            ))?);
             emit_load_rax_imm(instrs, next_ip)?;
             emit_push_rax(instrs)?;
-            // op0 might refer to rax, but we've already saved it to gs:[0]
-            // and clobbered the live rax. Reload from gs:[0] before reading
-            // op0 if it uses rax.
-            if op0_reads_rax(t) {
-                emit_load_rax_from_gs(instrs, 0)?;
-            }
-            emit_load_rax_from_op0(instrs, t)?;
+            emit_load_rax_from_gs(instrs, RBX_SLOT)?;
         }
         FlowControl::Return => {
             emit_save_rax(instrs)?;
@@ -316,14 +328,6 @@ fn emit_load_rax_from_op0(instrs: &mut Vec<Instruction>, t: &Instruction) -> Res
     Ok(())
 }
 
-fn op0_reads_rax(t: &Instruction) -> bool {
-    match t.op0_kind() {
-        OpKind::Register => t.op0_register() == Register::RAX,
-        OpKind::Memory => t.memory_base() == Register::RAX || t.memory_index() == Register::RAX,
-        _ => false,
-    }
-}
-
 fn extract_memory_operand(t: &Instruction) -> MemoryOperand {
     MemoryOperand::new(
         t.memory_base(),
@@ -353,8 +357,6 @@ fn emit_cond_select(
     taken: u64,
     fallthrough: u64,
 ) -> Result<(), Error> {
-    // gs:[8] is the rbx slot; see the `gs_qword(0)` rax slot in `emit_save_rax`.
-    const RBX_SLOT: i64 = 8;
     let cmov = jcc_to_cmov(jcc_code)?;
     emit_save_rax(instrs)?;
     // gs:[rbx] <- taken, staged through rax (there is no `mov m64, imm64`).

--- a/testing/conformance/abi/indirect-call.c
+++ b/testing/conformance/abi/indirect-call.c
@@ -1,0 +1,69 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// An indirect call must read its target operand using the stack pointer the
+// guest had *before* the call -- exactly as hardware does: `CALL m` computes
+// the target from memory, then pushes the return address. A translator that
+// rewrites the call by pushing the return address first and only then reading
+// the operand evaluates an rsp-relative target against the post-push rsp,
+// reading 8 bytes off and branching to garbage. `call qword ptr [rsp+disp]`
+// is common in real code (it is how bash crashed: `ff 54 24 58`).
+//
+// We stage the correct target at [rsp+0x58] and a decoy at [rsp+0x50] (the
+// slot a translator that pushed first would read instead), then call through
+// [rsp+0x58]. The right target returns one sentinel, the decoy another, so
+// the bug is caught as a clean wrong answer rather than relying on a crash.
+
+#include <stdint.h>
+
+#if defined(__x86_64__) && defined(__linux__)
+
+int main(void) {
+    uint64_t result = 0;
+    asm volatile(
+        "sub $0x100, %%rsp\n\t"            // scratch frame (16-byte multiple)
+        "lea 1f(%%rip), %%rax\n\t"
+        "mov %%rax, 0x58(%%rsp)\n\t"       // correct target
+        "lea 3f(%%rip), %%rax\n\t"
+        "mov %%rax, 0x50(%%rsp)\n\t"       // decoy at the off-by-8 slot
+        "call *0x58(%%rsp)\n\t"           // indirect call through the stack
+        "jmp 2f\n\t"
+        "1:\n\t" "movq $0x600d, %[r]\n\t" "ret\n\t"   // reached iff rsp was right
+        "3:\n\t" "movq $0x0bad, %[r]\n\t" "ret\n\t"   // reached iff read was off by 8
+        "2:\n\t"
+        "add $0x100, %%rsp\n\t"
+        : [r] "=r"(result)
+        :
+        : "rax", "cc", "memory");
+
+    return result == 0x600d ? 0 : 1;
+}
+
+#elif defined(__aarch64__) && defined(__APPLE__)
+
+// AArch64 has no memory-operand call and BL/BLR records the return address in
+// the link register, not on the stack -- so adjusting sp is never part of a
+// call and the hazard above cannot arise. The invariant still holds: an
+// indirect call through a value loaded from the stack must reach that target.
+// Load a function pointer from a stack slot and `blr` it.
+int main(void) {
+    uint64_t result = 0;
+    asm volatile(
+        "sub sp, sp, #0x100\n\t"
+        "adr x9, 1f\n\t"
+        "str x9, [sp, #0x58]\n\t"
+        "ldr x9, [sp, #0x58]\n\t"
+        "blr x9\n\t"
+        "b 2f\n\t"
+        "1:\n\t" "movz %[r], #0x600d\n\t" "ret\n\t"
+        "2:\n\t"
+        "add sp, sp, #0x100\n\t"
+        : [r] "=r"(result)
+        :
+        : "x9", "x30", "cc", "memory");
+
+    return result == 0x600d ? 0 : 1;
+}
+
+#else
+#error "unsupported host for indirect-call test"
+#endif


### PR DESCRIPTION
The IndirectCall terminator pushed the return address and only then read the
call's target operand. For an rsp-relative target like `call qword ptr
[rsp+0x58]` (bytes ff 54 24 58 -- common in real code) the push had already
decremented rsp by 8, so the operand was read from [rsp+0x50] instead: the
call branched 8 bytes off, to garbage. Hardware evaluates `CALL m`'s target
with the pre-push rsp, then pushes. This is what sent interactive bash to a
wild 0x8000 and crashed it.

Read the target operand first, while rsp (and rax) still hold the guest's
values, stash it in the rbx slot, then push the return address and reload the
target. Reading the operand before clobbering rax also makes rax-based targets
(`call [rax+8]`) correct without the special case, so op0_reads_rax goes away.

Add testing/conformance/abi/indirect-call.c: stage the target at [rsp+0x58]
and a decoy at the off-by-8 slot [rsp+0x50], call through [rsp+0x58], and
check the right target is reached.