### PR TITLE
runtime: drop dead Darwin port and unsupported-host stubs

### DIFF
--- a/runtime/examples/strace/main.rs
+++ b/runtime/examples/strace/main.rs
@@ -11,10 +11,8 @@
 //! `post_syscall(&SystemCall)`. The `SystemCall` value carries the number,
 //! argument registers, and the final result when one exists.
 //!
-//! The Linux argument decoders are the rich ones (signal names, open
-//! flags, struct stat, etc.). The Darwin port (with arm64 syscall numbers
-//! and Mach traps) is intentionally smaller — it prints names and raw
-//! args, leaving full decoding for later.
+//! The argument decoders are the rich ones: signal names, open flags,
+//! struct stat, and so on.
 
 use mimalloc::MiMalloc;
 
@@ -24,19 +22,8 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn main() -> std::process::ExitCode {
-    eprintln!("strace example only supports Linux and macOS hosts");
-    std::process::ExitCode::from(2)
-}
-
-#[cfg(target_os = "linux")]
 use linux::main;
 
-#[cfg(target_os = "macos")]
-use darwin::main;
-
-#[cfg(target_os = "linux")]
 mod linux {
 
     use std::{env, fmt::Write, process::ExitCode, ptr};
@@ -752,130 +739,3 @@ mod linux {
         }
     }
 } // mod linux
-
-#[cfg(target_os = "macos")]
-mod darwin {
-
-    use std::{env, process::ExitCode};
-
-    use chimera::{Sandbox, SyscallResult, SystemCall, SystemCalls};
-
-    pub fn main() -> ExitCode {
-        let mut argv = env::args_os().skip(1);
-        let program = match argv.next() {
-            Some(p) => p,
-            None => {
-                eprintln!("usage: strace <program> [args...]");
-                return ExitCode::from(2);
-            }
-        };
-        let prog_args: Vec<_> = argv.collect();
-
-        let mut sandbox = match Sandbox::new(&program) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("strace: {e}");
-                return ExitCode::FAILURE;
-            }
-        };
-        sandbox.args(prog_args).system_calls(Strace);
-
-        match sandbox.run() {
-            Ok(status) => ExitCode::from(status.code() as u8),
-            Err(e) => {
-                eprintln!("strace: {e}");
-                ExitCode::FAILURE
-            }
-        }
-    }
-
-    struct Strace;
-
-    impl SystemCalls for Strace {
-        fn post_syscall(&mut self, call: &SystemCall) {
-            let name = syscall_name(call.number);
-            let line = format_call(name, call);
-            match call.result() {
-                Some(result) => {
-                    let ret_str = match result {
-                        SyscallResult::Error(errno) => format!("-1 (errno {})", errno),
-                        SyscallResult::Ok(v) => format!("{:#x}", v),
-                    };
-                    eprintln!("{:<48} = {}", line, ret_str);
-                }
-                None => {
-                    eprintln!("{:<48} = ?", line);
-                }
-            }
-        }
-    }
-
-    fn format_call(name: &str, c: &SystemCall) -> String {
-        // For most syscalls we print three positional args — enough to scan
-        // logs by eye without re-implementing every Mach/BSD struct decoder.
-        format!(
-            "{}({:#x}, {:#x}, {:#x})",
-            name, c.args[0], c.args[1], c.args[2]
-        )
-    }
-
-    fn syscall_name(n: u64) -> &'static str {
-        // Darwin's userspace ABI: positive numbers are BSD syscalls, negative
-        // (interpreted as a signed 32-bit value) are Mach traps. We use the
-        // raw u64 here, so values with bit 31 set look like very large
-        // positive numbers — match them as such.
-        match n {
-            // BSD syscalls — common subset of /usr/include/sys/syscall.h.
-            1 => "exit",
-            2 => "fork",
-            3 => "read",
-            4 => "write",
-            5 => "open",
-            6 => "close",
-            7 => "wait4",
-            20 => "getpid",
-            24 => "getuid",
-            33 => "access",
-            37 => "kill",
-            38 => "readlink",
-            39 => "getppid",
-            42 => "pipe",
-            46 => "sigaction",
-            48 => "sigprocmask",
-            53 => "sigaltstack",
-            54 => "ioctl",
-            73 => "munmap",
-            74 => "mprotect",
-            75 => "madvise",
-            92 => "fcntl",
-            170 => "csops",
-            174 => "csops_audittoken",
-            197 => "mmap",
-            202 => "sysctl",
-            220 => "mlock",
-            294 => "psynch_cvclrprepost",
-            333 => "pthread_canceled",
-            336 => "proc_info",
-            339 => "fstat64",
-            372 => "csops_audittoken",
-            381 => "csops",
-            483 => "bsdthread_register",
-            500 => "thread_selfid",
-            521 => "abort_with_payload",
-            // Special: Apple's threading TSD setup.
-            0x80000000 => "thread_set_tsd_base",
-            // Mach traps (the kernel reads x16 as a signed 32-bit value; in
-            // u64 they appear as 0xFFFFFFFF_FFFFFFXX).
-            0xFFFFFFFFFFFFFFE4 => "task_self_trap",
-            0xFFFFFFFFFFFFFFE3 => "host_self_trap",
-            0xFFFFFFFFFFFFFFE6 => "mach_reply_port",
-            0xFFFFFFFFFFFFFFE1 => "mach_msg_trap",
-            0xFFFFFFFFFFFFFFF1 => "_kernelrpc_mach_vm_protect_trap",
-            0xFFFFFFFFFFFFFFF2 => "_kernelrpc_mach_vm_deallocate_trap",
-            0xFFFFFFFFFFFFFFF4 => "_kernelrpc_mach_vm_allocate_trap",
-            0xFFFFFFFFFFFFFFF6 => "_kernelrpc_mach_vm_map_trap",
-            0xFFFFFFFFFFFFFFED => "_kernelrpc_mach_port_deallocate_trap",
-            _ => "syscall",
-        }
-    }
-} // mod darwin

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -12,10 +12,7 @@ mod syscall;
 
 pub use syscall::{Passthrough, SyscallResult, SystemCall, SystemCalls};
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub use sys::linux::syscall::host_syscall;
-#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
-pub use syscall::host_syscall;
 
 /// A sandboxed guest program, configured but not yet running.
 pub struct Sandbox {
@@ -130,13 +127,6 @@ pub enum Error {
     /// bind/rebase opcode, …).
     #[error("unsupported guest feature: {0}")]
     Unsupported(String),
-
-    /// Chimera is itself running on a host platform it doesn't support.
-    #[error("unsupported host platform {os}-{arch}: Chimera runtime supports Linux and macOS")]
-    UnsupportedHost {
-        os: &'static str,
-        arch: &'static str,
-    },
 }
 
 impl Error {

--- a/runtime/sys/linux/exec.rs
+++ b/runtime/sys/linux/exec.rs
@@ -143,7 +143,7 @@ fn exec_errno(err: &Error) -> Option<i32> {
     match err {
         Error::Io { source, .. } => Some(source.raw_os_error().unwrap_or(libc::EIO)),
         Error::BadBinary(_) | Error::Link(_) | Error::Unsupported(_) => Some(libc::ENOEXEC),
-        Error::CodeCacheExhausted | Error::Translate(_) | Error::UnsupportedHost { .. } => None,
+        Error::CodeCacheExhausted | Error::Translate(_) => None,
     }
 }
 

--- a/runtime/sys/mod.rs
+++ b/runtime/sys/mod.rs
@@ -9,22 +9,3 @@ pub mod mmap;
 
 #[cfg(target_os = "linux")]
 pub use linux::exec;
-
-#[cfg(not(any(target_os = "linux")))]
-pub mod exec {
-    use std::{ffi::OsString, path::Path};
-
-    use crate::{Error, SystemCalls};
-
-    pub fn execv(
-        _program: &Path,
-        _args: &[OsString],
-        _envs: Option<&[(OsString, OsString)]>,
-        _handler: Box<dyn SystemCalls>,
-    ) -> Result<i32, Error> {
-        Err(Error::UnsupportedHost {
-            os: std::env::consts::OS,
-            arch: std::env::consts::ARCH,
-        })
-    }
-}

--- a/runtime/syscall.rs
+++ b/runtime/syscall.rs
@@ -2,16 +2,12 @@
 //! handlers, the [`SystemCalls`] trait, the runtime's syscall driver
 //! [`syscall`], and the default [`Passthrough`] handler.
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-use crate::sys::linux::syscall::host_syscall as host_syscall_;
-
-#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
-use host::host_syscall as host_syscall_;
+use crate::sys::linux::syscall::host_syscall;
 
 /// A single guest system call, presented to a [`SystemCalls`] handler.
 ///
 /// `number` is the syscall number from the guest's syscall-number register
-/// (`rax` on x86-64, `x16` on Darwin/arm64). `args` contains the six argument
+/// (`rax` on x86-64). `args` contains the six argument
 /// registers in the guest ABI's syscall order. The handler decides what the
 /// call should do — forward it to the host kernel via
 /// [`crate::host_syscall`], synthesize an answer with
@@ -22,33 +18,17 @@ pub struct SystemCall {
     /// The six argument registers.
     pub args: [u64; 6],
     return_value: i64,
-    is_error: bool,
     has_result: bool,
 }
 
 impl SystemCall {
-    /// Write `result` into this `SystemCall` in the host's syscall-return ABI.
-    /// On Linux, `Error(errno)` is encoded as `-errno` in the return slot with
-    /// the error flag clear; on Darwin, it's encoded as positive `errno` with
-    /// the error flag set so the dispatcher can drive the NZCV carry bit.
+    /// Write `result` into this `SystemCall` in the host's syscall-return ABI:
+    /// `Error(errno)` is encoded as `-errno` in the return slot, the way the
+    /// Linux/x86-64 kernel reports a failed syscall.
     pub fn set_result(&mut self, result: SyscallResult) {
         match result {
-            SyscallResult::Ok(value) => {
-                self.set_return(value);
-                self.set_error(false);
-            }
-            SyscallResult::Error(errno) => {
-                #[cfg(target_os = "macos")]
-                {
-                    self.set_return(errno as i64);
-                    self.set_error(true);
-                }
-                #[cfg(not(target_os = "macos"))]
-                {
-                    self.set_return(-(errno as i64));
-                    self.set_error(false);
-                }
-            }
+            SyscallResult::Ok(value) => self.set_return(value),
+            SyscallResult::Error(errno) => self.set_return(-(errno as i64)),
         }
     }
 
@@ -60,14 +40,6 @@ impl SystemCall {
         self.has_result = true;
     }
 
-    /// Mark this syscall as an error. On Darwin/arm64, the dispatcher
-    /// translates this into the NZCV carry flag the guest's libc expects.
-    /// On Linux/x86-64 the bit is ignored — errors are conveyed by setting
-    /// a negative return value.
-    pub fn set_error(&mut self, is_error: bool) {
-        self.is_error = is_error;
-    }
-
     /// Return the syscall outcome currently stored in this value.
     ///
     /// Returns `None` when no result exists yet, which is the case in
@@ -77,21 +49,10 @@ impl SystemCall {
         if !self.has_result {
             return None;
         }
-        #[cfg(target_os = "macos")]
-        {
-            if self.is_error {
-                Some(SyscallResult::Error(self.return_value as i32))
-            } else {
-                Some(SyscallResult::Ok(self.return_value))
-            }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            if (-4095..0).contains(&self.return_value) {
-                Some(SyscallResult::Error((-self.return_value) as i32))
-            } else {
-                Some(SyscallResult::Ok(self.return_value))
-            }
+        if (-4095..0).contains(&self.return_value) {
+            Some(SyscallResult::Error((-self.return_value) as i32))
+        } else {
+            Some(SyscallResult::Ok(self.return_value))
         }
     }
 
@@ -99,17 +60,11 @@ impl SystemCall {
         self.return_value
     }
 
-    #[allow(dead_code)] // Read only by the Darwin/arm64 dispatcher.
-    pub(crate) fn is_error(&self) -> bool {
-        self.is_error
-    }
-
     pub(crate) fn new(number: u64, args: [u64; 6]) -> Self {
         Self {
             number,
             args,
             return_value: 0,
-            is_error: false,
             has_result: false,
         }
     }
@@ -130,7 +85,7 @@ pub trait SystemCalls {
     ///
     /// The default implementation forwards the call to the host kernel.
     fn do_syscall(&mut self, call: &mut SystemCall) {
-        call.set_result(host_syscall_(call));
+        call.set_result(host_syscall(call));
     }
 
     /// Observe a guest syscall after its final result is known, if any.
@@ -146,8 +101,7 @@ impl SystemCalls for Passthrough {}
 /// The outcome the host kernel reported for a forwarded syscall, or that a
 /// runtime intercept synthesized in lieu of forwarding. `Ok(value)` is the
 /// kernel's success value; `Error(errno)` carries the positive errno. The
-/// ABI difference between Linux ("errno in `-rax`") and Darwin ("errno in
-/// `x0` with the NZCV carry bit set") is hidden inside
+/// kernel's "errno in `-rax`" convention is hidden inside
 /// [`crate::host_syscall`] and [`SystemCall::set_result`]; handlers see one
 /// portable shape either way.
 #[derive(Copy, Clone)]
@@ -158,18 +112,15 @@ pub enum SyscallResult {
     Error(i32),
 }
 
-// === Host-specific syscall driver ===
+// === Syscall driver ===
 //
-// `syscall` (on Linux) is the runtime entry the arch dispatcher calls once per
-// guest syscall instruction: it intercepts the calls Chimera must service
-// itself (`exit`/`exit_group`, `execve`/`execveat`, `arch_prctl`, the
-// `mmap` family) and hands the rest to the embedder hooks. On Darwin and
-// unsupported hosts the file only exposes `host_syscall` — the unified
-// driver is Linux-only for now.
+// `syscall` is the runtime entry the arch dispatcher calls once per guest
+// syscall instruction: it intercepts the calls Chimera must service itself
+// (`exit`/`exit_group`, `execve`/`execveat`, `arch_prctl`, the `mmap` family)
+// and hands the rest to the embedder hooks.
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 mod host {
-    use super::{SyscallResult, SystemCall, SystemCalls, host_syscall_};
+    use super::{SyscallResult, SystemCall, SystemCalls, host_syscall};
     use crate::arch::dispatch::Thread;
 
     /// Drive one guest syscall. Runtime-owned syscalls are serviced inline
@@ -255,7 +206,7 @@ mod host {
         }
 
         if call.number == libc::SYS_mmap as u64 {
-            let result = host_syscall_(call);
+            let result = host_syscall(call);
             if let SyscallResult::Ok(addr) = result {
                 thread
                     .addr_space()
@@ -267,7 +218,7 @@ mod host {
         }
 
         if call.number == libc::SYS_munmap as u64 {
-            let result = host_syscall_(call);
+            let result = host_syscall(call);
             if matches!(result, SyscallResult::Ok(_)) {
                 thread
                     .addr_space()
@@ -279,7 +230,7 @@ mod host {
         }
 
         if call.number == libc::SYS_mremap as u64 {
-            let result = host_syscall_(call);
+            let result = host_syscall(call);
             if let SyscallResult::Ok(new_start) = result {
                 let flags = call.args[3] as libc::c_int;
                 let dontunmap = (flags & libc::MREMAP_DONTUNMAP) != 0;
@@ -301,81 +252,4 @@ mod host {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-mod host {
-    use std::arch::asm;
-
-    use super::{SyscallResult, SystemCall};
-
-    /// Forward `call` to the host kernel and return the result. Darwin's
-    /// kernel signals errors via the NZCV carry flag rather than as a
-    /// negative return value, so the carry bit becomes [`SyscallResult::Error`]
-    /// and the value field carries the positive errno.
-    ///
-    /// Darwin's `exit` (BSD syscall #1) is intercepted: forwarding it to
-    /// the host kernel would terminate Chimera itself, so it no-ops and
-    /// returns 0.
-    pub fn host_syscall(call: &SystemCall) -> SyscallResult {
-        if call.number == 1 {
-            return SyscallResult::Ok(0);
-        }
-        // `__abort_with_payload` (BSD #521): if dyld asserts during the
-        // bring-up we are still bringing online, forwarding the call would
-        // terminate Chimera too. Pretend it succeeded.
-        if call.number == 521 {
-            return SyscallResult::Ok(0);
-        }
-        // `thread_set_tsd_base` (syscall #0x80000000 on arm64 Darwin):
-        // forwarding would clobber the same register Chimera's Rust runtime
-        // uses to find its own pthread state.
-        if call.number == 0x80000000 {
-            return SyscallResult::Ok(0);
-        }
-
-        // Darwin's userspace syscall ABI: number in x16, args in x0..x5,
-        // `svc #0x80`. Return value lands in x0; the carry flag indicates
-        // an error, in which case x0 holds the positive errno.
-        let ret: i64;
-        let cflag: u64;
-        unsafe {
-            asm!(
-                "svc #0x80",
-                "cset {cflag}, cs",
-                in("x16") call.number,
-                inout("x0") call.args[0] => ret,
-                in("x1") call.args[1],
-                in("x2") call.args[2],
-                in("x3") call.args[3],
-                in("x4") call.args[4],
-                in("x5") call.args[5],
-                cflag = lateout(reg) cflag,
-                options(nostack, preserves_flags),
-            );
-        }
-        if cflag != 0 {
-            SyscallResult::Error(ret as i32)
-        } else {
-            SyscallResult::Ok(ret)
-        }
-    }
-}
-
-#[cfg(not(any(
-    all(target_arch = "x86_64", target_os = "linux"),
-    all(target_arch = "aarch64", target_os = "macos"),
-)))]
-mod host {
-    use super::{SyscallResult, SystemCall};
-
-    /// Stub used on hosts Chimera has not been ported to. Always reports
-    /// `ENOSYS`.
-    pub fn host_syscall(_call: &SystemCall) -> SyscallResult {
-        SyscallResult::Error(libc::ENOSYS)
-    }
-}
-
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub use host::syscall;
-
-#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
-pub use host::host_syscall;


### PR DESCRIPTION
Chimera only builds on x86_64 Linux, but syscall.rs carried a half-finished Darwin/arm64 host_syscall (svc #0x80, Mach/BSD intercepts) and an ENOSYS "unsupported host" stub alongside it. That fork forced cfg-gated import aliases (host_syscall_) in both syscall.rs and lib.rs purely to dodge a name collision, and an is_error/set_error path that only ever fed Darwin's NZCV carry bit.

Remove all of it:

  - the Darwin and stub `mod host` blocks, leaving one plain `use crate::sys::linux::syscall::host_syscall`
  - the cfg-forked re-exports in syscall.rs and lib.rs
  - the macos branches in set_result()/result(), keeping the Linux `-errno` encoding
  - the is_error field, set_error(), and is_error() getter (always false and never read on Linux)
  - the Error::UnsupportedHost variant and the not(linux) exec fallback
  - the strace example's mod darwin and its platform dispatch

The cfg gates in arch/mod.rs and sys/mod.rs stay: they have no fallback body, so a wrong host yields an honest compile error rather than a stub.

Builds clean; all conformance tests pass.