### PR TITLE
Add `make ci` to run GitHub Actions locally with Agent CI

### DIFF
--- a/.github/agent-ci.Dockerfile
+++ b/.github/agent-ci.Dockerfile
@@ -1,0 +1,33 @@
+# Runner image for `make ci` (Agent CI, https://agent-ci.dev/).
+#
+# Agent CI's default runner image, ghcr.io/actions/actions-runner:latest, is a
+# minimal container that ships neither system build tools nor a Rust toolchain
+# (unlike GitHub's hosted ubuntu-latest VM). This image layers in what the CI
+# workflow needs: a C compiler and make for the conformance suite, python3 to
+# drive testing/lit.py, and rustup with the pinned toolchain.
+#
+# Agent CI hashes this file and caches the built image, so edits rebuild it
+# (~60-90s) and unchanged runs reuse the cache.
+FROM ghcr.io/actions/actions-runner:latest
+
+RUN sudo apt-get update \
+ && sudo apt-get install -y --no-install-recommends \
+      build-essential \
+      pkg-config \
+      python3 \
+      curl \
+      ca-certificates \
+ && sudo rm -rf /var/lib/apt/lists/*
+
+# Install rustup and the toolchain. Keep the channel and components in sync with
+# rust-toolchain.toml; rustup also honours that file at runtime, but installing
+# here bakes the toolchain into the cached image instead of re-fetching per run.
+#
+# The GitHub Actions runner does not propagate this image's ENV PATH to `run:`
+# step shells, so symlink the rustup proxies into /usr/local/bin, which is on
+# the runner's default PATH. The proxies dispatch on argv[0], so a cargo ->
+# rustup symlink still resolves to the cargo toolchain.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain 1.95.0 \
+                 --component rustfmt,clippy \
+ && sudo ln -s /home/runner/.cargo/bin/* /usr/local/bin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,5 @@ CLI options live in `opts.rs` and are derived with [`argh`](https://github.com/g
 ## Tests
 
 `make conformance` builds Chimera and runs each test under it; `make conformance-native` runs the same tests directly without Chimera. The runner is `testing/lit.py`, modeled after LLVM's LIT: each test source carries one or more `// RUN:` directives that the runner expands and executes. Tests live under `testing/conformance/` and are organized by topic.
+
+`make ci` runs the GitHub Actions workflow (`.github/workflows/ci.yml` — rustfmt, clippy, build, test, conformance) locally with [Agent CI](https://agent-ci.dev/), reproducing what GitHub runs on push. It uses a custom runner image, `.github/agent-ci.Dockerfile`, that adds the build toolchain and rustup the default minimal runner lacks; keep its pinned toolchain in sync with `rust-toolchain.toml`.

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ build:
 check: conformance-native conformance
 .PHONY: check
 
+# Run the GitHub Actions CI workflow locally with Agent CI (https://agent-ci.dev/).
+ci:
+	npx @redwoodjs/agent-ci run --workflow .github/workflows/ci.yml
+.PHONY: ci
+
 conformance: build
 	python3 testing/lit.py --runner "$(RUNNER)"
 .PHONY: conformance


### PR DESCRIPTION
Run the CI workflow (.github/workflows/ci.yml) locally via Agent CI
(https://agent-ci.dev/), so the full rustfmt/clippy/build/test/conformance
pipeline can be reproduced without pushing.

The default Agent CI runner image is minimal and ships neither the build
toolchain nor rustup, so add a custom .github/agent-ci.Dockerfile that
installs build-essential, pkg-config, python3, and rustup pinned to the
rust-toolchain.toml channel. The GitHub Actions runner does not propagate
the image ENV PATH to run-step shells, so the rustup proxies are symlinked
into /usr/local/bin.
