### PR TITLE
runtime: strip PROT_EXEC from guest mappings (W^X)

### DIFF
--- a/runtime/sys/linux/elf.rs
+++ b/runtime/sys/linux/elf.rs
@@ -223,8 +223,15 @@ pub fn map_elf(parsed: &ParsedElf) -> Result<LoadedElf, Error> {
         if ph.p_flags & PF_W != 0 {
             prot |= libc::PROT_WRITE;
         }
+        // W^X: Chimera never executes guest pages natively — the dispatcher
+        // reads them and runs translated blocks from the code cache — so an
+        // executable segment is mapped read-only rather than `PROT_EXEC`. This
+        // mirrors the `PROT_EXEC` stripping the syscall driver applies to the
+        // libraries the dynamic linker maps later; here it covers the
+        // executable and interpreter images the runtime maps itself, which
+        // never pass through that path. `PROT_READ` keeps them translatable.
         if ph.p_flags & PF_X != 0 {
-            prot |= libc::PROT_EXEC;
+            prot |= libc::PROT_READ;
         }
 
         let map_flags = if ehdr.e_type == ET_EXEC {

--- a/runtime/syscall.rs
+++ b/runtime/syscall.rs
@@ -77,6 +77,11 @@ impl SystemCall {
 /// [`SystemCalls::pre_syscall`] and [`SystemCalls::post_syscall`] can observe
 /// every guest syscall, including the few Chimera intercepts for its own
 /// correctness (`exit`, `execve`, `arch_prctl`, `mmap`, `munmap`, `mremap`).
+///
+/// Chimera also rewrites the `prot` argument of `mmap`, `mprotect`, and
+/// `pkey_mprotect` before servicing them, clearing `PROT_EXEC` (see
+/// [`crate::syscall::syscall`]). `pre_syscall` sees the guest's original
+/// request; every later stage, including `do_syscall`, sees the rewritten one.
 pub trait SystemCalls {
     /// Observe a guest syscall before Chimera or the embedder services it.
     fn pre_syscall(&mut self, _call: &SystemCall) {}
@@ -150,8 +155,31 @@ mod host {
     /// to the host kernel itself so its guest-mapping bookkeeping stays
     /// authoritative. Embedders can observe them in `pre_syscall()` and
     /// `post_syscall()`, but they do not reach `do_syscall()`.
+    ///
+    /// Finally, Chimera enforces a W^X invariant on the guest: the guest never
+    /// executes its own pages natively — the dispatcher reads them and runs
+    /// translated blocks from the code cache — so freshly mapped or re-protected
+    /// guest code must never be executable in the host page tables. Before any
+    /// dispatch, the `prot` argument of `mmap`, `mprotect`, and `pkey_mprotect`
+    /// (always `args[2]`) has `PROT_EXEC` replaced with `PROT_READ`, so a stray
+    /// native jump into guest code faults instead of running untranslated while
+    /// the translator can still read the bytes it will translate (an
+    /// execute-only mapping would otherwise become `PROT_NONE`). Unlike the
+    /// `mmap` family, `mprotect`/`pkey_mprotect` are not otherwise
+    /// runtime-owned: they still reach `do_syscall()`, only with `PROT_EXEC`
+    /// already cleared from their argument.
     pub fn syscall(thread: &mut Thread, call: &mut SystemCall, handler: &mut dyn SystemCalls) {
         handler.pre_syscall(call);
+
+        if call.number == libc::SYS_mmap as u64
+            || call.number == libc::SYS_mprotect as u64
+            || call.number == libc::SYS_pkey_mprotect as u64
+        {
+            let prot = call.args[2] as libc::c_int;
+            if prot & libc::PROT_EXEC != 0 {
+                call.args[2] = ((prot & !libc::PROT_EXEC) | libc::PROT_READ) as u64;
+            }
+        }
 
         if call.number == libc::SYS_exit_group as u64 || call.number == libc::SYS_exit as u64 {
             thread.exit_code = call.args[0] as i32;


### PR DESCRIPTION
The guest never executes its own pages natively: the dispatcher reads
them and runs translated blocks from the code cache. So no guest page
should ever be executable in the host page tables, lest a stray native
jump into guest code run untranslated, outside the sandbox.

Clear PROT_EXEC from the `prot` argument of mmap, mprotect, and
pkey_mprotect before servicing them, preserving (and adding) PROT_READ
so the translator can still read the bytes it will translate. mprotect
and pkey_mprotect still reach the embedder's do_syscall, only with the
exec bit already cleared, so the invariant holds regardless of policy.
The executable and interpreter images the runtime maps itself bypass the
syscall path, so map their PF_X segments read-only too.

The stripping is transparent to the guest: these calls return success as
if exec had been granted. The one remaining leak is /proc/self/maps,
which reflects the host's real page tables; that seam closes when proc
is virtualized.
