### PR TITLE
Signal delivery polling

### DIFF
--- a/runtime/arch/x86/dispatch.rs
+++ b/runtime/arch/x86/dispatch.rs
@@ -87,7 +87,8 @@ impl Thread {
                 ib_rcx: 0,
                 ib_rdx: 0,
                 ib_host: 0,
-                _align_fpstate: [0; 3],
+                exit_requested: 0,
+                _align_fpstate: [0; 5],
                 fpstate: [0; XSAVE_AREA_SIZE],
             }),
             addr_space: AddressSpace::new()?,
@@ -133,6 +134,24 @@ impl Thread {
         }
     }
 
+    /// Recompute the safepoint exit flag the translated loop-closing polls read.
+    /// It is set exactly when a signal is pending and not blocked, so a fully
+    /// linked guest loop is forced back into this run loop within one iteration to
+    /// deliver it; once nothing is deliverable it clears, leaving warm loops
+    /// poll-free at runtime. Clear first, then re-arm only if deliverable — never
+    /// re-clearing — so a same-thread catcher that sets the flag from a signal
+    /// handler between the clear and the recheck is not lost. The `compiler_fence`
+    /// keeps the clear ordered before the recheck (signal delivery on this thread
+    /// is itself a serialization point, so no CPU fence is needed).
+    fn refresh_exit_requested(&mut self) {
+        self.state.exit_requested = 0;
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        let deliverable = crate::sys::linux::signal::pending_snapshot() & !self.signals.blocked;
+        if deliverable != 0 {
+            self.state.exit_requested = 1;
+        }
+    }
+
     /// Set the thread's entry registers for a freshly mapped image, without
     /// touching its address space. Used to re-enter after an `execve` once the
     /// caller has torn down the old image and mapped the new one.
@@ -160,6 +179,7 @@ impl Thread {
 
         while self.running {
             self.deliver_pending_signals();
+            self.refresh_exit_requested();
 
             let ts_ptr: *mut ThreadState = &mut *self.state;
 
@@ -299,8 +319,15 @@ pub struct ThreadState {
     pub ib_rcx: u64,
     pub ib_rdx: u64,
     pub ib_host: u64,
+    /// Asynchronous-exit flag polled by translated code at loop-closing edges.
+    /// The host signal catcher sets it; the run loop recomputes it each iteration
+    /// as "a deliverable signal is pending" so it self-clears. When set, a fully
+    /// linked, syscall-free guest loop is dragged back to the run loop within one
+    /// iteration, where a pending signal is delivered at a real block boundary.
+    /// Reached from translated code as `gs:[]`.
+    pub exit_requested: u32,
     /// Padding so `fpstate` lands at offset 256 (a 64-byte boundary).
-    _align_fpstate: [u64; 3],
+    _align_fpstate: [u32; 5],
     /// XSAVE area for the guest's extended FP/SIMD state (x87, SSE, AVX,
     /// AVX-512). Saved on every exit, restored on every entry. Must be
     /// 64-byte aligned; the field layout above guarantees offset 256.
@@ -331,7 +358,8 @@ impl ThreadState {
         self.ib_rcx = 0;
         self.ib_rdx = 0;
         self.ib_host = 0;
-        self._align_fpstate = [0; 3];
+        self.exit_requested = 0;
+        self._align_fpstate = [0; 5];
         self.fpstate.fill(0);
 
         // XRSTOR loads MXCSR from the legacy region (bytes 24..28) of the save

--- a/runtime/arch/x86/dispatch.rs
+++ b/runtime/arch/x86/dispatch.rs
@@ -11,6 +11,7 @@
 //! assembly lives in [`super::trampoline`].
 
 use std::arch::asm;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::{
     Error, SystemCall, SystemCalls,
@@ -87,7 +88,7 @@ impl Thread {
                 ib_rcx: 0,
                 ib_rdx: 0,
                 ib_host: 0,
-                exit_requested: 0,
+                exit_requested: AtomicU32::new(0),
                 _align_fpstate: [0; 5],
                 fpstate: [0; XSAVE_AREA_SIZE],
             }),
@@ -144,11 +145,11 @@ impl Thread {
     /// keeps the clear ordered before the recheck (signal delivery on this thread
     /// is itself a serialization point, so no CPU fence is needed).
     fn refresh_exit_requested(&mut self) {
-        self.state.exit_requested = 0;
-        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        self.state.exit_requested.store(0, Ordering::Relaxed);
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
         let deliverable = crate::sys::linux::signal::pending_snapshot() & !self.signals.blocked;
         if deliverable != 0 {
-            self.state.exit_requested = 1;
+            self.state.exit_requested.store(1, Ordering::Relaxed);
         }
     }
 
@@ -325,7 +326,14 @@ pub struct ThreadState {
     /// linked, syscall-free guest loop is dragged back to the run loop within one
     /// iteration, where a pending signal is delivered at a real block boundary.
     /// Reached from translated code as `gs:[]`.
-    pub exit_requested: u32,
+    ///
+    /// `AtomicU32` because the signal catcher writes it asynchronously (from the
+    /// handler, via `gs:[]`) while the run loop reads and writes it; plain accesses
+    /// would be a data race the compiler could miscompile (e.g. drop the clear in
+    /// [`Thread::refresh_exit_requested`] as a dead store). The in-memory layout is
+    /// an identical 32-bit word at the same offset, so the `gs:[]` poll is
+    /// unaffected.
+    pub exit_requested: AtomicU32,
     /// Padding so `fpstate` lands at offset 256 (a 64-byte boundary).
     _align_fpstate: [u32; 5],
     /// XSAVE area for the guest's extended FP/SIMD state (x87, SSE, AVX,
@@ -358,7 +366,7 @@ impl ThreadState {
         self.ib_rcx = 0;
         self.ib_rdx = 0;
         self.ib_host = 0;
-        self.exit_requested = 0;
+        self.exit_requested.store(0, Ordering::Relaxed);
         self._align_fpstate = [0; 5];
         self.fpstate.fill(0);
 

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -308,7 +308,7 @@ pub fn translate(
     if let Some(link) = classify_terminator(&term) {
         emit_body(cache, &instrs, host_pc, guest_pc)?;
         let term_pc = cache.next_pc() as usize;
-        let (bytes, rel_edges) = build_linked_terminator(&link, exit_tramp);
+        let (bytes, rel_edges) = build_linked_terminator(&link, exit_tramp, guest_pc);
         cache.emit(&bytes)?;
         let edges = rel_edges
             .into_iter()
@@ -418,23 +418,68 @@ fn classify_terminator(t: &Instruction) -> Option<LinkTerm> {
     }
 }
 
+/// Whether an edge to `target` from a block starting at `block_start` closes a
+/// loop: its successor lies at or before the block's own start, so it is a
+/// backward edge. Only such edges carry the asynchronous-signal safepoint poll;
+/// forward (straight-line) edges stay poll-free so non-looping code is
+/// unaffected. Every guest loop closes via a direct back-branch (handled here)
+/// or an indirect branch (handled in the shared inline lookup routine).
+fn is_back_edge(target: u64, block_start: u64) -> bool {
+    target <= block_start
+}
+
+/// Emit the asynchronous-signal safepoint poll for a loop-closing edge:
+/// `cmp dword ptr gs:[exit_requested], 0` then `jne rel32`. Returns the offset of
+/// the reserved `rel32`, which the caller patches to the edge's cold-exit stub.
+/// When the flag is set the branch is taken and the stub publishes the successor
+/// guest PC and exits to the dispatcher, where the pending signal is delivered;
+/// when clear the loop continues on the fast path. (The `cmp` clobbers the host
+/// flags; a later change makes this flag-preserving.)
+fn emit_exit_poll(out: &mut Vec<u8>) -> usize {
+    let disp = offset_of!(ThreadState, exit_requested) as i32;
+    // cmp dword ptr gs:[disp32], 0 — 65 83 3C 25 <disp32> 00
+    out.extend_from_slice(&[0x65, 0x83, 0x3C, 0x25]);
+    emit_u32(out, disp as u32);
+    out.push(0x00);
+    // jne rel32 — 0F 85 <rel32>
+    out.extend_from_slice(&[0x0F, 0x85]);
+    take_rel32(out)
+}
+
 /// Build the raw machine code for a linkable terminator: a fast-path direct
 /// branch followed by one cold exit stub per successor. Returns the encoded
 /// bytes and, for each edge, the byte offset of its fast-path `rel32`
 /// displacement paired with the successor's guest PC. The displacements are
 /// initialized to target the stubs; the dispatcher rewrites them to the
 /// successor blocks as those are translated.
-fn build_linked_terminator(link: &LinkTerm, exit_tramp: u64) -> (Vec<u8>, Vec<(usize, u64)>) {
+///
+/// A back-edge ([`is_back_edge`]) is preceded by a safepoint poll
+/// ([`emit_exit_poll`]) that diverts to the edge's own cold-exit stub when an
+/// asynchronous signal is pending, so a fully linked loop returns to the run loop
+/// within one iteration. The stub already publishes the correct successor guest
+/// PC, so delivery lands at a clean boundary.
+fn build_linked_terminator(
+    link: &LinkTerm,
+    exit_tramp: u64,
+    block_start: u64,
+) -> (Vec<u8>, Vec<(usize, u64)>) {
     let mut out = Vec::new();
     let mut edges = Vec::new();
     match *link {
         LinkTerm::Uncond { target } => {
+            // An unconditional back-branch is the whole loop: poll before taking
+            // it. The poll's `cmp` clobbers flags, but an unconditional jmp has no
+            // flag-dependent terminator (a later change makes the poll flag-safe).
+            let poll = is_back_edge(target, block_start).then(|| emit_exit_poll(&mut out));
             // jmp rel32 -> stub (later: -> target's host code)
             out.push(0xE9);
             let rel = take_rel32(&mut out);
             let stub = out.len();
             emit_stub(&mut out, target, exit_tramp);
             write_rel32(&mut out, rel, stub);
+            if let Some(poll_rel) = poll {
+                write_rel32(&mut out, poll_rel, stub);
+            }
             edges.push((rel, target));
         }
         LinkTerm::Cond {
@@ -442,20 +487,46 @@ fn build_linked_terminator(link: &LinkTerm, exit_tramp: u64) -> (Vec<u8>, Vec<(u
             taken,
             fallthrough,
         } => {
-            // jcc rel32 -> taken stub ; jmp rel32 -> fall-through stub.
-            // The native jcc reads the block's live guest flags directly.
-            out.extend_from_slice(&[0x0F, opcode]);
-            let jcc_rel = take_rel32(&mut out);
-            out.push(0xE9);
-            let jmp_rel = take_rel32(&mut out);
-            let taken_stub = out.len();
-            emit_stub(&mut out, taken, exit_tramp);
-            let fall_stub = out.len();
-            emit_stub(&mut out, fallthrough, exit_tramp);
-            write_rel32(&mut out, jcc_rel, taken_stub);
-            write_rel32(&mut out, jmp_rel, fall_stub);
-            edges.push((jcc_rel, taken));
-            edges.push((jmp_rel, fallthrough));
+            // The fall-through is `next_ip`, always forward, so only the taken edge
+            // can close a loop. When it does, route the taken path through a poll
+            // after the guest's `jcc` has consumed the live flags.
+            if is_back_edge(taken, block_start) {
+                // jcc rel32 -> taken_check ; jmp rel32 -> fall stub.
+                out.extend_from_slice(&[0x0F, opcode]);
+                let jcc_rel = take_rel32(&mut out);
+                out.push(0xE9);
+                let jmp_rel = take_rel32(&mut out);
+                // taken_check: poll, then the linkable fast-path branch to taken.
+                let taken_check = out.len();
+                write_rel32(&mut out, jcc_rel, taken_check);
+                let poll_rel = emit_exit_poll(&mut out);
+                out.push(0xE9);
+                let taken_jmp_rel = take_rel32(&mut out);
+                let taken_stub = out.len();
+                emit_stub(&mut out, taken, exit_tramp);
+                let fall_stub = out.len();
+                emit_stub(&mut out, fallthrough, exit_tramp);
+                write_rel32(&mut out, jmp_rel, fall_stub);
+                write_rel32(&mut out, taken_jmp_rel, taken_stub);
+                write_rel32(&mut out, poll_rel, taken_stub);
+                edges.push((taken_jmp_rel, taken));
+                edges.push((jmp_rel, fallthrough));
+            } else {
+                // jcc rel32 -> taken stub ; jmp rel32 -> fall-through stub.
+                // The native jcc reads the block's live guest flags directly.
+                out.extend_from_slice(&[0x0F, opcode]);
+                let jcc_rel = take_rel32(&mut out);
+                out.push(0xE9);
+                let jmp_rel = take_rel32(&mut out);
+                let taken_stub = out.len();
+                emit_stub(&mut out, taken, exit_tramp);
+                let fall_stub = out.len();
+                emit_stub(&mut out, fallthrough, exit_tramp);
+                write_rel32(&mut out, jcc_rel, taken_stub);
+                write_rel32(&mut out, jmp_rel, fall_stub);
+                edges.push((jcc_rel, taken));
+                edges.push((jmp_rel, fallthrough));
+            }
         }
         LinkTerm::DirectCall { target, ret } => {
             // Push the 64-bit return address with a single 8-byte store so the

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -187,6 +187,21 @@ impl CodeCache {
         out.extend_from_slice(&[0x0f, 0x85]); // jne miss
         let jne_rel = take_rel32(&mut out);
 
+        // Asynchronous-signal safepoint poll. Every guest loop that stays in the
+        // cache via an indirect branch (a computed-goto or function-pointer
+        // dispatch loop hitting this table) closes here, so without a poll a
+        // pending signal would never reach a block boundary. If the exit flag is
+        // set, divert to the miss path, which already publishes the resolved target
+        // (gs:[target]) as the next guest PC and returns to the dispatcher —
+        // delivering at a clean boundary with the right guest PC. The guest's flags
+        // are saved in gs:[ib_flags] here (restored on both the hit and miss
+        // paths), so this `cmp`'s flag clobber is harmless.
+        out.extend_from_slice(&[0x65, 0x83, 0x3c, 0x25]); // cmp dword ptr gs:[exit_requested], 0
+        emit_u32(&mut out, offset_of!(ThreadState, exit_requested) as u32);
+        out.push(0x00);
+        out.extend_from_slice(&[0x0f, 0x85]); // jne miss
+        let poll_rel = take_rel32(&mut out);
+
         // Hit: load the host PC, restore flags and the borrowed registers, and
         // jump into the successor block with the full guest register file live.
         out.extend_from_slice(&[0x48, 0x8b, 0x50, 0x08]); // mov rdx, [rax+8]
@@ -202,6 +217,7 @@ impl CodeCache {
         // guest PC, and exit to the dispatcher exactly as before.
         let miss = out.len();
         write_rel32(&mut out, jne_rel, miss);
+        write_rel32(&mut out, poll_rel, miss);
         emit_restore_flags(&mut out, d_flags);
         gs_load(&mut out, MODRM_RCX, d_rcx); // mov rcx, gs:[rcx]
         gs_load(&mut out, MODRM_RDX, d_rdx); // mov rdx, gs:[rdx]

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -584,11 +584,23 @@ fn build_linked_terminator(
             movabs_rax(&mut out, ret); // movabs rax, ret
             out.push(0x50); // push rax
             gs_load(&mut out, MODRM_RAX, RAX_SLOT); // mov rax, gs:[rax_slot]
+            // A direct call whose target is at or before this block can close a
+            // loop with no back-branch and no `ret`: direct or mutual recursion
+            // through fixed call targets, which otherwise stays entirely inside
+            // linked call edges until the stack overflows. Poll after the return
+            // address is pushed (so the call's effect is complete) but before the
+            // branch, so a pending signal is delivered at the callee entry. Every
+            // call cycle contains an edge into its lowest-address member, so this
+            // catches the cycle even when the individual calls run forward.
+            let poll = is_back_edge(target, block_start).then(|| emit_exit_poll(&mut out));
             out.push(0xE9);
             let rel = take_rel32(&mut out);
             let stub = out.len();
             emit_stub(&mut out, target, exit_tramp);
             write_rel32(&mut out, rel, stub);
+            if let Some(poll_rel) = poll {
+                write_rel32(&mut out, poll_rel, stub);
+            }
             edges.push((rel, target));
         }
     }

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -428,22 +428,46 @@ fn is_back_edge(target: u64, block_start: u64) -> bool {
     target <= block_start
 }
 
-/// Emit the asynchronous-signal safepoint poll for a loop-closing edge:
-/// `cmp dword ptr gs:[exit_requested], 0` then `jne rel32`. Returns the offset of
-/// the reserved `rel32`, which the caller patches to the edge's cold-exit stub.
-/// When the flag is set the branch is taken and the stub publishes the successor
-/// guest PC and exits to the dispatcher, where the pending signal is delivered;
-/// when clear the loop continues on the fast path. (The `cmp` clobbers the host
-/// flags; a later change makes this flag-preserving.)
+/// Emit the asynchronous-signal safepoint poll for a loop-closing edge. Returns
+/// the offset of a reserved `rel32` the caller patches to the edge's cold-exit
+/// stub: when `exit_requested` is set the poll branches there (the stub publishes
+/// the successor guest PC and exits to the dispatcher, where the pending signal is
+/// delivered); when clear it falls through to the caller's fast-path branch. On
+/// both paths the borrowed register is restored, so the full guest register file
+/// stays live across the edge.
+///
+/// The poll must not perturb the guest's arithmetic flags: a valid loop can carry
+/// a flag across its back-edge — an `adc`/`sbb` reduction closed by `dec`/`jnz`
+/// relies on `dec` preserving CF for the next iteration's `adc` — so a
+/// flag-clobbering `cmp` would make such a loop misexecute the moment it is
+/// linked. It therefore tests the flag with `jrcxz`, which neither reads nor
+/// writes the arithmetic flags, borrowing rcx through the `ib_rcx` scratch slot.
+/// That slot is otherwise owned only by the inline indirect-branch lookup routine,
+/// which a linked terminator never runs, and a thread executes these strictly
+/// sequentially, so the borrow cannot collide. The 32-bit load zero-extends the
+/// `u32` flag into rcx, so `jrcxz` sees zero exactly when no signal is pending.
 fn emit_exit_poll(out: &mut Vec<u8>) -> usize {
-    let disp = offset_of!(ThreadState, exit_requested) as i32;
-    // cmp dword ptr gs:[disp32], 0 — 65 83 3C 25 <disp32> 00
-    out.extend_from_slice(&[0x65, 0x83, 0x3C, 0x25]);
-    emit_u32(out, disp as u32);
-    out.push(0x00);
-    // jne rel32 — 0F 85 <rel32>
-    out.extend_from_slice(&[0x0F, 0x85]);
-    take_rel32(out)
+    let d_exit = offset_of!(ThreadState, exit_requested) as i32;
+    let d_rcx = offset_of!(ThreadState, ib_rcx) as i32;
+    // mov gs:[ib_rcx], rcx — stash guest rcx (no flags touched).
+    gs_store(out, MODRM_RCX, d_rcx);
+    // mov ecx, gs:[exit_requested] — rcx = flag, zero-extended (no flags touched).
+    out.extend_from_slice(&[0x65, 0x8b, 0x0c, 0x25]);
+    emit_u32(out, d_exit as u32);
+    // jrcxz .cont — take the fast path if the flag is clear; preserves flags.
+    out.push(0xe3);
+    let jrcxz_at = out.len();
+    out.push(0x00); // rel8, patched to .cont below
+    // Flag set: restore guest rcx, then jump to the edge's cold-exit stub.
+    gs_load(out, MODRM_RCX, d_rcx);
+    out.push(0xe9);
+    let stub_rel = take_rel32(out);
+    // .cont: flag clear — restore guest rcx and continue on the fast path.
+    let cont = out.len();
+    let disp = cont as i64 - (jrcxz_at as i64 + 1);
+    out[jrcxz_at] = i8::try_from(disp).expect("jrcxz poll displacement out of range") as u8;
+    gs_load(out, MODRM_RCX, d_rcx);
+    stub_rel
 }
 
 /// Build the raw machine code for a linkable terminator: a fast-path direct
@@ -468,8 +492,8 @@ fn build_linked_terminator(
     match *link {
         LinkTerm::Uncond { target } => {
             // An unconditional back-branch is the whole loop: poll before taking
-            // it. The poll's `cmp` clobbers flags, but an unconditional jmp has no
-            // flag-dependent terminator (a later change makes the poll flag-safe).
+            // it. The poll preserves the guest's flags and registers (see
+            // emit_exit_poll), so a loop carrying flags across this edge is safe.
             let poll = is_back_edge(target, block_start).then(|| emit_exit_poll(&mut out));
             // jmp rel32 -> stub (later: -> target's host code)
             out.push(0xE9);
@@ -488,8 +512,9 @@ fn build_linked_terminator(
             fallthrough,
         } => {
             // The fall-through is `next_ip`, always forward, so only the taken edge
-            // can close a loop. When it does, route the taken path through a poll
-            // after the guest's `jcc` has consumed the live flags.
+            // can close a loop. When it does, route the taken path through a
+            // flag-preserving poll once the guest's `jcc` has read the live flags;
+            // the poll keeps them intact for the loop head on the fast path.
             if is_back_edge(taken, block_start) {
                 // jcc rel32 -> taken_check ; jmp rel32 -> fall stub.
                 out.extend_from_slice(&[0x0F, opcode]);

--- a/runtime/sys/linux/signal.rs
+++ b/runtime/sys/linux/signal.rs
@@ -249,6 +249,27 @@ extern "C" fn chimera_sigcatch(
             }
         }
         PENDING.fetch_or(1u64 << (signo as u64 - 1), Ordering::Release);
+
+        // Drag the interrupted guest thread back to its run loop. Translated code
+        // keeps the guest registers live across linked block chains and only
+        // returns to the dispatcher at a block exit, so a tight syscall-free loop
+        // would never observe the bit set above. Set the per-context exit flag the
+        // loop-closing polls in translated code read, so the next such poll falls
+        // back to the dispatcher, where delivery happens at a real block boundary.
+        // GS is this thread's `ThreadState` throughout guest execution (bound once
+        // via `ARCH_SET_GS`, never changed — only FS is swapped), so a single
+        // `gs:[]` store reaches the right context with no TLS, allocation, or
+        // locking, keeping the catcher async-signal-safe. This sets the flag on the
+        // interrupted thread's own context; cross-thread fan-out (signal caught on
+        // a thread other than the one that should deliver) is out of scope and
+        // needs per-context pending state. TODO: route by owning context.
+        unsafe {
+            core::arch::asm!(
+                "mov dword ptr gs:[{off}], 1",
+                off = const core::mem::offset_of!(ThreadState, exit_requested),
+                options(nostack, preserves_flags),
+            );
+        }
     }
 }
 

--- a/testing/conformance/signals/async-direct-recursion.c
+++ b/testing/conformance/signals/async-direct-recursion.c
@@ -1,0 +1,58 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// An asynchronous signal must reach the guest handler even when the guest is
+// looping purely through linked direct-call edges — direct recursion with no
+// back-branch and no `ret`. Such a cycle stays entirely in the code cache until
+// the stack overflows, so without a safepoint poll on the direct-call back-edge
+// the pending signal is never delivered. Each call does only straight-line work
+// (no loop, so no competing back-edge poll can deliver the signal instead),
+// which also slows the recursion enough that the signal lands long before the
+// stack overflows. A helper child raises the signal; if delivery regresses, the
+// child's watchdog kill bounds the failure instead of hanging the suite.
+
+#include <signal.h>
+#include <stdint.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// A handful of slow `idiv`s per call: enough to keep the recursion well short of
+// overflow for tens of ms (so the signal lands first) while keeping the
+// straight-line block far under the translator's basic-block size limit.
+#define V8(x) x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr;
+#define V64(x) V8(x) V8(x) V8(x) V8(x) V8(x) V8(x) V8(x) V8(x)
+
+static volatile uint64_t sink;
+static volatile uint64_t dvr = 1000003;
+
+static void on_sig(int sig) {
+    (void) sig;
+    _exit(0); // delivery into the guest handler == success
+}
+
+static void recurse(void) {
+    uint64_t x = sink + 0x9e3779b97f4a7c15ull;
+    V64(x) // straight-line work: slows the call rate, no back-edge of its own
+    sink = x;
+    recurse(); // direct self-call: the only loop-closing edge (compiled at -O0,
+               // so it is a real `call`, not a tail-call `jmp`)
+}
+
+int main(void) {
+    struct sigaction sa = {0};
+    sa.sa_handler = on_sig;
+    if (sigaction(SIGUSR1, &sa, 0) != 0) return 1;
+
+    pid_t parent = getpid();
+    pid_t helper = fork();
+    if (helper < 0) return 2;
+    if (helper == 0) {
+        usleep(50000); // let the parent get deep into the recursion
+        kill(parent, SIGUSR1);
+        usleep(3000000); // watchdog: if delivery regressed, force a bounded exit
+        kill(parent, SIGKILL);
+        _exit(0);
+    }
+
+    recurse(); // never returns: the handler exits, or we overflow without the fix
+    return 3;  // unreachable
+}

--- a/testing/conformance/signals/async-direct-recursion.c
+++ b/testing/conformance/signals/async-direct-recursion.c
@@ -23,9 +23,15 @@
 
 static volatile uint64_t sink;
 static volatile uint64_t dvr = 1000003;
+static volatile sig_atomic_t helper_pid;
 
 static void on_sig(int sig) {
     (void) sig;
+    // Stop the watchdog helper before exiting (kill is async-signal-safe), so it
+    // can't outlive us and later SIGKILL a recycled PID.
+    if (helper_pid > 0) {
+        kill((pid_t) helper_pid, SIGKILL);
+    }
     _exit(0); // delivery into the guest handler == success
 }
 
@@ -42,6 +48,17 @@ int main(void) {
     sa.sa_handler = on_sig;
     if (sigaction(SIGUSR1, &sa, 0) != 0) return 1;
 
+    // Block SIGUSR1 until helper_pid is published. Otherwise, if the parent is
+    // descheduled past the helper's initial sleep, the signal could arrive before
+    // the assignment below, the handler would take the success path without
+    // stopping the helper, and the watchdog would survive to SIGKILL a recycled
+    // PID. A signal that arrives while blocked stays pending and is delivered the
+    // moment we unblock — after helper_pid is set.
+    sigset_t block, old;
+    sigemptyset(&block);
+    sigaddset(&block, SIGUSR1);
+    if (sigprocmask(SIG_BLOCK, &block, &old) != 0) return 4;
+
     pid_t parent = getpid();
     pid_t helper = fork();
     if (helper < 0) return 2;
@@ -52,6 +69,8 @@ int main(void) {
         kill(parent, SIGKILL);
         _exit(0);
     }
+    helper_pid = helper; // published before SIGUSR1 can be delivered (see above)
+    sigprocmask(SIG_SETMASK, &old, 0); // now safe to deliver
 
     recurse(); // never returns: the handler exits, or we overflow without the fix
     return 3;  // unreachable

--- a/testing/conformance/signals/async-indirect-loop.c
+++ b/testing/conformance/signals/async-indirect-loop.c
@@ -1,0 +1,54 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// The indirect-branch variant of async-tight-loop: a computed-goto dispatch
+// loop that closes via an indirect jump kept resident in the inline IB cache,
+// never returning to the run loop. Delivery therefore depends on the safepoint
+// poll inside the shared IB-lookup routine rather than the back-edge poll. A
+// watchdog child bounds a regression to a non-zero exit instead of a hang.
+
+#include <signal.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got;
+
+static void on_alarm(int sig) {
+    (void) sig;
+    got = 1;
+}
+
+int main(void) {
+    struct sigaction sa = {0};
+    sa.sa_handler = on_alarm;
+    if (sigaction(SIGALRM, &sa, 0) != 0) return 1;
+
+    pid_t parent = getpid();
+    pid_t wd = fork();
+    if (wd < 0) return 2;
+    if (wd == 0) {
+        sleep(5);
+        kill(parent, SIGKILL);
+        _exit(0);
+    }
+
+    struct itimerval it = {0};
+    it.it_value.tv_usec = 50000; // 50ms
+    if (setitimer(ITIMER_REAL, &it, 0) != 0) return 3;
+
+    // Computed-goto loop: each iteration jumps indirectly through a table indexed
+    // by the volatile flag, so the back-edge is a genuine indirect branch (no
+    // direct conditional back-edge). After warm-up the target hits the inline IB
+    // cache and the loop stays in the code cache.
+    void *targets[2];
+    targets[0] = &&spin;
+    targets[1] = &&done;
+    volatile unsigned long x = 0;
+spin:
+    x = x * 2654435761u + 1;
+    goto *targets[got != 0];
+done:
+    kill(wd, SIGKILL);
+    waitpid(wd, 0, 0);
+    return 0;
+}

--- a/testing/conformance/signals/async-tight-loop.c
+++ b/testing/conformance/signals/async-tight-loop.c
@@ -1,0 +1,53 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// An asynchronous signal must reach the guest handler even while the guest is in
+// a tight, syscall-free compute loop fully linked in the code cache. Such a loop
+// closes via a conditional back-edge that never returns to the run loop, so
+// before the safepoint poll a pending SIGALRM sat undelivered and this spun
+// forever. A watchdog child hard-kills us if that regresses, so the failure is a
+// bounded non-zero exit rather than a hung suite.
+
+#include <signal.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static volatile sig_atomic_t got;
+
+static void on_alarm(int sig) {
+    (void) sig;
+    got = 1;
+}
+
+int main(void) {
+    struct sigaction sa = {0};
+    sa.sa_handler = on_alarm;
+    if (sigaction(SIGALRM, &sa, 0) != 0) return 1;
+
+    // Watchdog: kill us after 5s if the signal never gets through, so a
+    // regression terminates (failing) instead of hanging forever.
+    pid_t parent = getpid();
+    pid_t wd = fork();
+    if (wd < 0) return 2;
+    if (wd == 0) {
+        sleep(5);
+        kill(parent, SIGKILL);
+        _exit(0);
+    }
+
+    struct itimerval it = {0};
+    it.it_value.tv_usec = 50000; // 50ms
+    if (setitimer(ITIMER_REAL, &it, 0) != 0) return 3;
+
+    // Tight, syscall-free reduction loop the translator fully links; the volatile
+    // flag is reloaded each iteration and the loop closes via a conditional
+    // back-edge whose safepoint poll must observe the pending signal.
+    volatile unsigned long x = 0;
+    while (!got) {
+        x = x * 2654435761u + 1;
+    }
+
+    kill(wd, SIGKILL);
+    waitpid(wd, 0, 0);
+    return 0;
+}

--- a/testing/conformance/signals/backedge-carry-flag.c
+++ b/testing/conformance/signals/backedge-carry-flag.c
@@ -1,0 +1,48 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// The safepoint poll on a linked conditional back-edge must not perturb the
+// guest's arithmetic flags. A multi-limb add carries the carry flag (CF) across
+// the loop's back-edge: each iteration's `adc` consumes the previous one's
+// carry, the index is stepped with `lea` (no flag effect), and the counter with
+// `dec` (which preserves CF and sets ZF for the `jnz`). The loop is a single
+// linked block, so the back-edge poll runs every iteration; a flag-clobbering
+// poll breaks the carry chain and corrupts the sum. No signal is needed — the
+// bug surfaces purely from the poll running on linked iterations.
+//
+// Adding all-ones + 1 across N limbs must yield all-zero limbs and a carry out.
+
+#include <stdint.h>
+
+#define N 64
+
+int main(void) {
+    static uint64_t a[N], b[N], r[N];
+    for (int i = 0; i < N; i++) {
+        a[i] = ~0ull;
+        b[i] = 0;
+        r[i] = 0;
+    }
+    b[0] = 1;
+
+    uint64_t idx = 0;
+    uint64_t cnt = N;
+    unsigned char carry;
+    __asm__ volatile(
+        "clc\n\t"
+        "1:\n\t"
+        "mov (%[a],%[i],8), %%rax\n\t"
+        "adc (%[b],%[i],8), %%rax\n\t" // consumes + produces CF
+        "mov %%rax, (%[r],%[i],8)\n\t"
+        "lea 1(%[i]), %[i]\n\t" // i++ without touching flags
+        "dec %[c]\n\t"          // preserves CF, sets ZF
+        "jnz 1b\n\t"            // back-edge; CF must reach the next adc
+        "setc %[carry]\n\t"
+        : [i] "+r"(idx), [c] "+r"(cnt), [carry] "=q"(carry)
+        : [a] "r"(a), [b] "r"(b), [r] "r"(r)
+        : "rax", "cc", "memory");
+
+    if (carry != 1) return 1;
+    for (int i = 0; i < N; i++)
+        if (r[i] != 0) return 2;
+    return 0;
+}


### PR DESCRIPTION
With block chaining, a loop can run in the code cache indefinitely, preventing signal delivery. Fix that up.