### PR TITLE
runtime: materialize the guest address for RIP-relative lea

### DIFF
--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -296,6 +296,8 @@ pub fn translate(
         break instr;
     };
 
+    rewrite_rip_relative_leas(&mut instrs)?;
+
     // A terminator with statically known target(s) — a direct jmp, a direct
     // call, or a supported conditional branch — gets the linkable layout: the
     // straight-line body, then a fast-path direct branch (initially aimed at a
@@ -321,6 +323,34 @@ pub fn translate(
         emit_body(cache, &instrs, host_pc, guest_pc)?;
         Ok((host_pc, Vec::new()))
     }
+}
+
+/// Rewrite each `lea reg, [rip + disp]` in the block body into a `movabs reg,
+/// <absolute guest target>` that materializes the same guest address.
+///
+/// `BlockEncoder` fixes up a RIP-relative operand by preserving its *effective
+/// address* — except when that address falls inside the very block being encoded,
+/// in which case it relocates the operand to the target's NEW location in the code
+/// cache. A computed `goto` compiles to `lea &&label(%rip)` with the label in the
+/// same basic block, so the encoder would hand back a code-cache address. Chimera
+/// needs the guest address instead: the value flows into an indirect branch that
+/// the dispatcher resolves as a guest PC. Materializing the absolute guest target
+/// up front sidesteps the relocation entirely (and produces the identical result
+/// for an ordinary out-of-block `lea`, so there is no behavior change there).
+///
+/// Only `lea r64, [rip+...]` is rewritten — the form compilers emit to take the
+/// address of code or data (computed gotos, function pointers, PIC). Other
+/// instructions reading RIP-relative *data* address memory outside the block, so
+/// the encoder preserves their target correctly and they are left untouched.
+fn rewrite_rip_relative_leas(instrs: &mut [Instruction]) -> Result<(), Error> {
+    for instr in instrs.iter_mut() {
+        if instr.code() == Code::Lea_r64_m && instr.is_ip_rel_memory_operand() {
+            let dest = instr.op0_register();
+            let target = instr.ip_rel_memory_address();
+            *instr = mkinstr(Instruction::with2(Code::Mov_r64_imm64, dest, target))?;
+        }
+    }
+    Ok(())
 }
 
 /// Encode the straight-line instruction list at `host_pc` (with RIP-relative

--- a/testing/conformance/abi/computed-goto.c
+++ b/testing/conformance/abi/computed-goto.c
@@ -1,0 +1,23 @@
+// RUN: %cc -O2 -fPIE %s -pie -o %t && timeout 5 %runner %t
+//
+// A computed-goto ("labels as values") loop. With GCC on this toolchain, the
+// `-O2 -fPIE -pie` shape emits `lea label(%rip)` for the label values and keeps
+// those labels in the same straight-line block as the indirect jump that later
+// consumes them. The translator must materialize the guest address; if it leaves
+// the encoder to relocate the block-internal RIP-relative operand into the code
+// cache, the indirect branch loses control flow and hangs. The `timeout` turns
+// that broken-runtime hang into a deterministic test failure.
+
+int main(void) {
+    static void *tab[2];
+    tab[0] = &&loop;
+    tab[1] = &&done;
+    unsigned long sum = 0;
+    int i = 0;
+loop:
+    sum += (unsigned) i;
+    i++;
+    goto *tab[i > 1000];
+done:
+    return sum == (1000UL * 1001UL / 2UL) ? 0 : 1;
+}


### PR DESCRIPTION
`BlockEncoder` fixes up a RIP-relative operand by preserving its effective
address — except when the target lies inside the block being encoded, where
it relocates the operand to the target's new location in the code cache. A
computed `goto` compiles to `lea &&label(%rip)` with the label in the same
basic block, so in a PIE binary the encoder handed back a code-cache address
instead of the guest address. The value then flows into an indirect branch
the dispatcher resolves as a guest PC, so it jumped into the cache and the
program lost control flow (a looping computed goto hung with no signal at
all). This is why the indirect-branch async-signal test passed on non-PIE
local builds but hung on CI, where the compiler defaults to PIE.

Rewrite `lea r64, [rip+...]` to `movabs r64, <absolute guest target>` before
encoding, so the materialized address is always the guest address (and the
result is identical for an ordinary out-of-block lea). Add an abi conformance
test: a computed-goto loop whose result a mis-relocated label corrupts.
