### PR TITLE
Make the translated-code cache size configurable, default 256 MiB

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -40,6 +40,9 @@ fn run(cmd: RunCmd) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    if let Some(mib) = cmd.code_cache_size {
+        sandbox.code_cache_size(mib.saturating_mul(1024 * 1024));
+    }
     match sandbox.args(cmd.args).run() {
         Ok(status) => ExitCode::from(status.code() as u8),
         Err(err) => {

--- a/cli/opts.rs
+++ b/cli/opts.rs
@@ -22,6 +22,10 @@ pub enum Command {
 #[derive(FromArgs)]
 #[argh(subcommand, name = "run")]
 pub struct RunCmd {
+    /// translated-code cache capacity in MiB (default 256)
+    #[argh(option)]
+    pub code_cache_size: Option<usize>,
+
     /// path to the program
     #[argh(positional)]
     pub program: PathBuf,

--- a/runtime/arch/x86/cache.rs
+++ b/runtime/arch/x86/cache.rs
@@ -29,9 +29,9 @@ pub struct BlockCache {
 }
 
 impl BlockCache {
-    pub fn new() -> Result<Self, Error> {
+    pub fn new(cache_size: usize) -> Result<Self, Error> {
         Ok(Self {
-            cache: CodeCache::new()?,
+            cache: CodeCache::new(cache_size)?,
             map: HashMap::new(),
             pending: HashMap::new(),
         })
@@ -94,7 +94,7 @@ impl BlockCache {
 
 /// Rewrite the `rel32` displacement at `site` (an address inside the RWX code
 /// cache) so its branch lands at `host_pc`. The displacement is measured from
-/// the end of its own four bytes. The cache is at most a few megabytes, so the
+/// the end of its own four bytes. The cache stays well under 2 GiB, so the
 /// signed distance always fits in an `i32`. Safe to do unsynchronized: patching
 /// only happens in the dispatcher, between cache entries, while no translated
 /// code is executing; x86 keeps instruction and data caches coherent.

--- a/runtime/arch/x86/dispatch.rs
+++ b/runtime/arch/x86/dispatch.rs
@@ -69,8 +69,9 @@ pub struct Thread {
 }
 
 impl Thread {
-    /// Create a new guest thread.
-    pub fn new(rip: u64, rsp: u64) -> Result<Self, Error> {
+    /// Create a new guest thread whose address space carries a
+    /// `code_cache_size`-byte translated-code cache.
+    pub fn new(rip: u64, rsp: u64, code_cache_size: usize) -> Result<Self, Error> {
         let guest_fs_base = current_fs_base();
         let mut thread = Self {
             state: Box::new(ThreadState {
@@ -92,7 +93,7 @@ impl Thread {
                 _align_fpstate: [0; 5],
                 fpstate: [0; XSAVE_AREA_SIZE],
             }),
-            addr_space: AddressSpace::new()?,
+            addr_space: AddressSpace::new(code_cache_size)?,
             signals: Signals::new(),
             running: false,
             exit_code: 0,

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -14,7 +14,6 @@ use crate::Error;
 
 use super::dispatch::ThreadState;
 
-const CACHE_SIZE: usize = 16 * 1024 * 1024;
 const MAX_BLOCK_GUEST_BYTES: usize = 4096;
 
 /// Inline indirect-branch lookup table: a direct-mapped, guest-readable mirror
@@ -62,11 +61,22 @@ pub struct CodeCache {
 }
 
 impl CodeCache {
-    pub fn new() -> Result<Self, Error> {
+    /// Create a code cache backed by a `size`-byte RWX region. The region is
+    /// `mmap`'d lazily, so unused capacity costs virtual address space, not
+    /// resident memory. `size` must stay under 2 GiB so every intra-cache
+    /// `rel32` branch displacement fits in an `i32` (see `patch_site` in the
+    /// block cache); [`Sandbox::run`](crate::Sandbox::run) rejects an
+    /// out-of-range size before any guest state exists, so by the time a
+    /// cache is built the bound is an invariant.
+    pub fn new(size: usize) -> Result<Self, Error> {
+        assert!(
+            size > 0 && size <= crate::MAX_CODE_CACHE_SIZE,
+            "code cache size {size} out of range"
+        );
         let p = unsafe {
             libc::mmap(
                 ptr::null_mut(),
-                CACHE_SIZE,
+                size,
                 libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC,
                 libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
                 -1,
@@ -88,12 +98,12 @@ impl CodeCache {
         };
         if t == libc::MAP_FAILED {
             let err = Error::last_os_error("ib table mmap");
-            unsafe { libc::munmap(p, CACHE_SIZE) };
+            unsafe { libc::munmap(p, size) };
             return Err(err);
         }
         let cache = Self {
             base: p as *mut u8,
-            size: CACHE_SIZE,
+            size,
             used: 0,
             ib_table: t as *mut u8,
             ib_lookup: None,

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -3,6 +3,7 @@
 
 use std::{
     ffi::{OsStr, OsString},
+    io,
     path::{Path, PathBuf},
 };
 
@@ -14,12 +15,27 @@ pub use syscall::{Passthrough, SyscallResult, SystemCall, SystemCalls};
 
 pub use sys::linux::syscall::host_syscall;
 
+/// Default capacity of the translated-code cache, in bytes. One cache is
+/// shared by every guest thread, so a multithreaded guest translates more
+/// blocks into it than a single-threaded one and runs a higher risk of
+/// exhausting it. Size it generously: the region is `mmap`'d lazily, so unused
+/// capacity costs virtual address space, not resident memory. It stays well
+/// under 2 GiB, so every intra-cache `rel32` displacement still fits in an
+/// `i32`.
+pub const DEFAULT_CODE_CACHE_SIZE: usize = 256 * 1024 * 1024;
+
+/// Upper bound on the translated-code cache capacity, in bytes. Every
+/// intra-cache `rel32` branch displacement is measured within the cache, so
+/// the cache must stay under 2 GiB for the displacement to fit in an `i32`.
+pub const MAX_CODE_CACHE_SIZE: usize = i32::MAX as usize;
+
 /// A sandboxed guest program, configured but not yet running.
 pub struct Sandbox {
     program: PathBuf,
     args: Vec<OsString>,
     envs: Option<Vec<(OsString, OsString)>>,
     handler: Box<dyn SystemCalls>,
+    code_cache_size: usize,
 }
 
 impl Sandbox {
@@ -31,6 +47,7 @@ impl Sandbox {
             args: Vec::new(),
             envs: None,
             handler: Box::new(Passthrough),
+            code_cache_size: DEFAULT_CODE_CACHE_SIZE,
         })
     }
 
@@ -62,6 +79,15 @@ impl Sandbox {
         self
     }
 
+    /// Set the translated-code cache capacity in bytes. Replaces the default
+    /// [`DEFAULT_CODE_CACHE_SIZE`]. Must be nonzero and at most
+    /// [`MAX_CODE_CACHE_SIZE`]; an out-of-range size is reported by
+    /// [`Sandbox::run`].
+    pub fn code_cache_size(&mut self, bytes: usize) -> &mut Self {
+        self.code_cache_size = bytes;
+        self
+    }
+
     /// Install a system-call handler. Replaces the default [`Passthrough`].
     pub fn system_calls<H: SystemCalls + 'static>(&mut self, handler: H) -> &mut Self {
         self.handler = Box::new(handler);
@@ -71,8 +97,27 @@ impl Sandbox {
     /// Run the guest. Returns when the guest issues `exit_group` (or `exit`),
     /// with the requested exit code; returns an error on setup failure.
     pub fn run(&mut self) -> Result<ExitStatus, Error> {
+        // Reject a bad cache size before anything is mapped: the guest image
+        // and stack go up before the thread (and its cache) exists and are
+        // recorded for cleanup only afterwards, so a late rejection would
+        // leak them in a long-lived embedder.
+        if self.code_cache_size == 0 || self.code_cache_size > MAX_CODE_CACHE_SIZE {
+            return Err(Error::io(
+                "code cache size",
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "must be nonzero and under 2 GiB",
+                ),
+            ));
+        }
         let handler = std::mem::replace(&mut self.handler, Box::new(Passthrough));
-        let code = sys::exec::execv(&self.program, &self.args, self.envs.as_deref(), handler)?;
+        let code = sys::exec::execv(
+            &self.program,
+            &self.args,
+            self.envs.as_deref(),
+            handler,
+            self.code_cache_size,
+        )?;
         Ok(ExitStatus { code })
     }
 }

--- a/runtime/sys/linux/exec.rs
+++ b/runtime/sys/linux/exec.rs
@@ -27,6 +27,7 @@ pub fn execv(
     args: &[OsString],
     envs: Option<&[(OsString, OsString)]>,
     mut handler: Box<dyn SystemCalls>,
+    code_cache_size: usize,
 ) -> Result<i32, Error> {
     // The first image's argv and envp come from the embedder: argv[0] is the
     // program path, then the supplied args; the environment is the explicit set
@@ -57,7 +58,7 @@ pub fn execv(
         interp_base,
     )?;
 
-    let mut thread = dispatch::Thread::new(rip, rsp)?;
+    let mut thread = dispatch::Thread::new(rip, rsp, code_cache_size)?;
     record_regions(
         thread.addr_space(),
         &main,

--- a/runtime/sys/mmap.rs
+++ b/runtime/sys/mmap.rs
@@ -19,9 +19,9 @@ pub struct AddressSpace {
 }
 
 impl AddressSpace {
-    pub fn new() -> Result<Self, Error> {
+    pub fn new(code_cache_size: usize) -> Result<Self, Error> {
         Ok(Self {
-            code: BlockCache::new()?,
+            code: BlockCache::new(code_cache_size)?,
             regions: Vec::new(),
         })
     }
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn add_region_coalesces_adjacent_ranges() {
-        let mut addr_space = AddressSpace::new().unwrap();
+        let mut addr_space = AddressSpace::new(crate::DEFAULT_CODE_CACHE_SIZE).unwrap();
         let base = mmap_anon(PAGE_SIZE * 2);
 
         addr_space.add_region(base, PAGE_SIZE);
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn remove_region_splits_partial_unmap() {
-        let mut addr_space = AddressSpace::new().unwrap();
+        let mut addr_space = AddressSpace::new(crate::DEFAULT_CODE_CACHE_SIZE).unwrap();
         let base = mmap_anon(PAGE_SIZE * 3);
         addr_space.add_region(base, PAGE_SIZE * 3);
 
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn remap_region_moves_mapping() {
-        let mut addr_space = AddressSpace::new().unwrap();
+        let mut addr_space = AddressSpace::new(crate::DEFAULT_CODE_CACHE_SIZE).unwrap();
         let old = mmap_anon(PAGE_SIZE);
         let new = mmap_anon(PAGE_SIZE);
 


### PR DESCRIPTION
One code-cache buffer is shared by every guest thread, so a
multithreaded guest translates more into it and exhausts it sooner than
a single-threaded one — and exhaustion is fatal. Grow the default from
16 MiB to 256 MiB: the region is mmap'd lazily, so the extra capacity
costs virtual address space, not resident memory.

The size is now a Sandbox knob rather than a translator constant.
Embedders set it with Sandbox::code_cache_size (in bytes); the CLI
exposes it as chimera run --code-cache-size (in MiB). Every intra-cache
rel32 branch displacement must fit in an i32, so the size is capped at
MAX_CODE_CACHE_SIZE (just under 2 GiB; the patch_site range note is
updated to match). Sandbox::run rejects an out-of-range size up front,
before the guest image and stack are mapped — a later failure would
leak those mappings in a long-lived embedder, since they are recorded
for cleanup only after the thread exists — and CodeCache::new asserts
the same bound as an invariant.
