### PR TITLE
runtime: apply close-on-exec at the emulated execve

### DIFF
--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -15,6 +15,10 @@ use crate::Error;
 use super::dispatch::ThreadState;
 
 const MAX_BLOCK_GUEST_BYTES: usize = 4096;
+/// Longest possible x86-64 instruction encoding. An instruction whose start
+/// lies within this many bytes of the decode window's end could be truncated by
+/// it, so the block is split there rather than risk decoding a partial encoding.
+const MAX_INSTR_LEN: u64 = 15;
 
 /// Inline indirect-branch lookup table: a direct-mapped, guest-readable mirror
 /// of the guest-PC -> host-PC map, probed from the code cache so that `ret`,
@@ -352,8 +356,22 @@ pub fn translate(
     let mut decoder = Decoder::with_ip(64, guest_bytes, guest_pc, DecoderOptions::NONE);
     let mut instrs = Vec::new();
     let mut instr = Instruction::default();
+    let window_end = guest_pc.wrapping_add(MAX_BLOCK_GUEST_BYTES as u64);
 
     let term = loop {
+        // A basic block can be longer than the fixed decode window — most often
+        // a long straight-line run such as a jump-table initializer. Decoding an
+        // instruction that straddles the window's end would feed iced a
+        // truncated encoding, which it reports as an invalid (Exception)
+        // instruction. Split the block at this instruction boundary instead:
+        // synthesize an unconditional jump to the next guest PC, which the
+        // dispatcher translates (and links) as its own block, resuming decode
+        // from a fresh window. Forward progress is guaranteed because the first
+        // instruction always starts `MAX_INSTR_LEN` short of the window end.
+        let next_pc = decoder.ip();
+        if next_pc.wrapping_add(MAX_INSTR_LEN) > window_end {
+            break mkinstr(Instruction::with_branch(Code::Jmp_rel32_64, next_pc))?;
+        }
         if !decoder.can_decode() {
             return Err(Error::Translate(format!(
                 "decoder ran out of bytes at {:#x}",

--- a/runtime/sys/linux/elf.rs
+++ b/runtime/sys/linux/elf.rs
@@ -4,7 +4,7 @@ use std::{
     ffi::OsStr,
     fs,
     os::{
-        fd::AsRawFd,
+        fd::{AsRawFd, RawFd},
         unix::{ffi::OsStrExt, fs::FileExt},
     },
     path::{Path, PathBuf},
@@ -98,6 +98,12 @@ pub struct ParsedElf {
     /// mutates the running image — the hazard every shared library has
     /// natively; a userspace loader cannot take `execve`'s `ETXTBSY` lock.
     file: fs::File,
+}
+
+impl AsRawFd for ParsedElf {
+    fn as_raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
 }
 
 /// Read an ELF image and validate that Chimera can run it, without mapping

--- a/runtime/sys/linux/exec.rs
+++ b/runtime/sys/linux/exec.rs
@@ -3,7 +3,11 @@
 
 use std::{
     ffi::{OsStr, OsString},
-    os::unix::ffi::OsStrExt,
+    fs,
+    os::{
+        fd::{AsRawFd, RawFd},
+        unix::ffi::OsStrExt,
+    },
     path::{Path, PathBuf},
     ptr,
     sync::Arc,
@@ -111,6 +115,12 @@ pub fn drive(thread: &mut dispatch::Thread, mut reason: ExitReason) -> Result<i3
                     .take_exec_request()
                     .expect("an Execve exit reason always has a published image");
 
+                let mut keep = vec![parsed.as_raw_fd()];
+                if let Some(interp) = &parsed_interp {
+                    keep.push(interp.as_raw_fd());
+                }
+                close_cloexec_fds(&keep)?;
+
                 // Tear down the old image (unmapping its regions, so a fixed
                 // ET_EXEC can reuse its addresses), then map the new one.
                 thread.addr_space().reset();
@@ -144,6 +154,38 @@ pub fn drive(thread: &mut dispatch::Thread, mut reason: ExitReason) -> Result<i3
         }
         reason = thread.run()?;
     }
+}
+
+/// Close every fd flagged close-on-exec, the way the kernel does when an exec
+/// commits. Chimera services `execve` by re-entering in place — no host exec
+/// runs — so `FD_CLOEXEC` must be applied by hand: the flag sits on the host
+/// fd (the guest's `O_CLOEXEC` and `F_SETFD` pass straight through), but the
+/// kernel honors it only at a real `execve`. Left open, a close-on-exec fd
+/// leaks into the new image — git's exec-failure notify pipe, for one, whose
+/// parent then waits forever for the EOF that close-on-exec was meant to
+/// deliver. `keep` names the runtime's own fds that must survive the install
+/// (the replacement image's files, still to be mapped); any runtime fd held
+/// across an exec must be listed there, since Rust opens files `O_CLOEXEC`.
+fn close_cloexec_fds(keep: &[RawFd]) -> Result<(), Error> {
+    let entries = fs::read_dir("/proc/self/fd")
+        .map_err(|e| Error::io("execve: listing /proc/self/fd".to_string(), e))?;
+    // Collect before closing: the directory walk holds an fd of its own, and
+    // closing entries out from under it would corrupt the walk. By the time
+    // the sweep runs the iterator has been dropped, so its fd fails the
+    // `F_GETFD` below and is skipped.
+    let fds: Vec<RawFd> = entries
+        .filter_map(|e| e.ok()?.file_name().to_str()?.parse().ok())
+        .collect();
+    for fd in fds {
+        if keep.contains(&fd) {
+            continue;
+        }
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags >= 0 && flags & libc::FD_CLOEXEC != 0 {
+            unsafe { libc::close(fd) };
+        }
+    }
+    Ok(())
 }
 
 /// A validated, parsed `execve` replacement image: everything needed to

--- a/testing/conformance/abi/long-block.c
+++ b/testing/conformance/abi/long-block.c
@@ -1,0 +1,53 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// A basic block longer than the translator's fixed decode window. The window
+// is read as a fixed-size slice of guest memory, so an instruction that
+// straddles its end is handed to the decoder truncated and misreported as
+// invalid -- which crashed translation of a long jump-table initializer in a
+// real binary (`translate: unhandled terminator ... flow_control=Exception
+// code=INVALID`). The translator must instead split an over-long block at an
+// instruction boundary and continue.
+//
+// The `.rept` emits one straight-line run of ~8000 bytes with no branches, well
+// past the 4096-byte window, forcing at least one split. The running sum is
+// carried across the split point, so a split that drops or duplicates an
+// instruction -- or resumes decode at the wrong guest PC -- yields the wrong
+// total rather than merely not crashing.
+
+#include <stdint.h>
+
+#define REPS 2000
+
+#if defined(__x86_64__) && defined(__linux__)
+
+int main(void) {
+    uint64_t acc = 0;
+    asm volatile(
+        ".rept 2000\n\t"
+        "add $1, %0\n\t"
+        ".endr\n\t"
+        : "+r"(acc)
+        :
+        : "cc");
+
+    return acc == REPS ? 0 : 1;
+}
+
+#elif defined(__aarch64__) && defined(__APPLE__)
+
+int main(void) {
+    uint64_t acc = 0;
+    asm volatile(
+        ".rept 2000\n\t"
+        "add %0, %0, #1\n\t"
+        ".endr\n\t"
+        : "+r"(acc)
+        :
+        : "cc");
+
+    return acc == REPS ? 0 : 1;
+}
+
+#else
+#error "unsupported host for long-block test"
+#endif

--- a/testing/conformance/exec/execve-cloexec.c
+++ b/testing/conformance/exec/execve-cloexec.c
@@ -1,0 +1,68 @@
+// A successful execve closes every fd flagged FD_CLOEXEC and leaves the rest
+// open. Chimera services execve in place, with no host exec to apply the flag,
+// so the runtime must sweep the fd table itself. The probe mirrors how git
+// launches its pager: the parent reads the CLOEXEC pipe expecting the EOF that
+// close-on-exec delivers, so a runtime that leaks the write end past the exec
+// hangs this read forever (caught by the RUN line's timeout) exactly as
+// `git diff` hung waiting on its exec-failure notify pipe.
+//
+// RUN: %cc %s -o %t && timeout 10 %runner %t
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    if (argc == 4 && strcmp(argv[1], "child") == 0) {
+        // The post-exec image: the plain fd must have survived the exec, the
+        // close-on-exec fd must not.
+        int keep_fd = atoi(argv[2]);
+        int gone_fd = atoi(argv[3]);
+        if (fcntl(gone_fd, F_GETFD) != -1 || errno != EBADF)
+            return 10;
+        if (write(keep_fd, "x", 1) != 1)
+            return 11;
+        return 0;
+    }
+
+    int gone[2]; // write end close-on-exec: the parent's read must see EOF
+    int keep[2]; // no flags: the exec'd child writes one byte through it
+    if (pipe(gone) != 0 || pipe(keep) != 0)
+        return 1;
+    if (fcntl(gone[1], F_SETFD, FD_CLOEXEC) != 0)
+        return 2;
+
+    pid_t pid = fork();
+    if (pid < 0)
+        return 3;
+    if (pid == 0) {
+        close(gone[0]);
+        close(keep[0]);
+        char keep_arg[16], gone_arg[16];
+        snprintf(keep_arg, sizeof(keep_arg), "%d", keep[1]);
+        snprintf(gone_arg, sizeof(gone_arg), "%d", gone[1]);
+        char *newargv[] = {argv[0], "child", keep_arg, gone_arg, 0};
+        execve(argv[0], newargv, 0);
+        _exit(127);
+    }
+    close(gone[1]);
+    close(keep[1]);
+
+    // EOF arrives only when the child's exec closes its inherited write end.
+    char c;
+    if (read(gone[0], &c, 1) != 0)
+        return 4;
+    if (read(keep[0], &c, 1) != 1 || c != 'x')
+        return 5;
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid)
+        return 6;
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return WIFEXITED(status) ? WEXITSTATUS(status) : 7;
+    return 0;
+}


### PR DESCRIPTION
Chimera services execve by re-entering in place, so no host exec ever
runs -- and FD_CLOEXEC sits on the host fd (the guest's O_CLOEXEC and
F_SETFD pass straight through) but the kernel honors it only at a real
execve. Every guest fd flagged close-on-exec therefore leaked into the
new image.

git's pager launch deadlocks on exactly this. start_command's parent
waits for EOF on an exec-failure notify pipe whose write end the child
marks FD_CLOEXEC before exec'ing less; with the flag never applied the
EOF never comes, the parent never leaves start_command, never closes
its end of the pager's stdin pipe, and the pager blocks reading it --
`git diff` on a tty hung before writing a byte.

Sweep /proc/self/fd when the exec installs, closing every fd whose
F_GETFD carries FD_CLOEXEC. The replacement image's own files -- held
open by ParsedElf, and O_CLOEXEC because Rust opens them that way --
are exempted: they are still to be mapped.

Test exec/execve-cloexec.c mirrors the pager shape: a close-on-exec
pipe whose read must see the exec's EOF, and an unflagged pipe that
must survive into the new image.