### PR TITLE
runtime: cache the pid for guest-memory copies

### DIFF
--- a/runtime/arch/x86/dispatch.rs
+++ b/runtime/arch/x86/dispatch.rs
@@ -209,6 +209,9 @@ impl Thread {
     /// is promoted to main and the copied [`Process`] group state is reset
     /// around it.
     pub fn reset_after_fork(&mut self) {
+        // The guest-copy pid cache still holds the parent's pid; drop it
+        // before anything reads guest memory in the child.
+        crate::sys::mmap::reset_cached_pid();
         self.is_main = true;
         self.state.tid.store(
             unsafe { libc::syscall(libc::SYS_gettid) } as i32,

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -43,6 +43,7 @@ impl Sandbox {
     /// Create a new sandbox for the given program.
     pub fn new(program: impl AsRef<Path>) -> Result<Self, Error> {
         arch::init()?;
+        sys::mmap::init()?;
         Ok(Self {
             program: program.as_ref().to_path_buf(),
             args: Vec::new(),

--- a/runtime/sys/mmap.rs
+++ b/runtime/sys/mmap.rs
@@ -1,7 +1,14 @@
 //! The guest address space: the translated-block cache ([`BlockCache`]) and the
 //! guest mappings Chimera owns on the host.
 
-use std::{collections::HashSet, sync::OnceLock};
+use std::{
+    collections::HashSet,
+    io,
+    sync::{
+        OnceLock,
+        atomic::{AtomicI32, Ordering},
+    },
+};
 
 use crate::{Error, arch::x86::cache::BlockCache};
 
@@ -246,6 +253,53 @@ impl Drop for AddressSpace {
     }
 }
 
+/// The runtime's pid, cached for the self-targeted `process_vm` copies below.
+/// glibc has not cached `getpid()` since 2.25, so taking it per copy doubles
+/// each copy's syscall bill — and the translator fetches its decode window
+/// through [`copy_from_guest`] once per translated block, which for a large
+/// program is over a million syscalls before it finishes starting. A fork
+/// invalidates the value (a stale pid would aim the copies at the *parent's*
+/// address space), so Chimera registers a `pthread_atfork` child hook for host
+/// forks and still drops the cache from [`Thread::reset_after_fork`] for the
+/// guest's raw-`clone` fork path, which never runs libc's fork handlers.
+///
+/// [`Thread::reset_after_fork`]: crate::arch::x86::dispatch::Thread::reset_after_fork
+static CACHED_PID: AtomicI32 = AtomicI32::new(0);
+
+extern "C" fn reset_cached_pid_after_fork() {
+    reset_cached_pid();
+}
+
+pub fn init() -> Result<(), Error> {
+    static INIT: OnceLock<Result<(), i32>> = OnceLock::new();
+
+    match INIT.get_or_init(|| {
+        let ret = unsafe { libc::pthread_atfork(None, None, Some(reset_cached_pid_after_fork)) };
+        if ret == 0 { Ok(()) } else { Err(ret) }
+    }) {
+        Ok(()) => Ok(()),
+        Err(err) => Err(Error::io(
+            "pthread_atfork",
+            io::Error::from_raw_os_error(*err),
+        )),
+    }
+}
+
+fn own_pid() -> libc::pid_t {
+    let pid = CACHED_PID.load(Ordering::Relaxed);
+    if pid != 0 {
+        return pid;
+    }
+    let pid = unsafe { libc::getpid() };
+    CACHED_PID.store(pid, Ordering::Relaxed);
+    pid
+}
+
+/// Drop the cached pid in the child of a fork; the next copy re-reads it.
+pub fn reset_cached_pid() {
+    CACHED_PID.store(0, Ordering::Relaxed);
+}
+
 /// Copy `buf.len()` bytes out of guest memory at `addr` without trusting the
 /// pointer. Chimera and the guest share one address space, so the copy is a
 /// self-targeted `process_vm_readv`: the kernel walks the page tables and an
@@ -268,7 +322,7 @@ pub fn copy_from_guest(addr: u64, buf: &mut [u8]) -> bool {
         iov_base: addr as *mut libc::c_void,
         iov_len: buf.len(),
     };
-    let copied = unsafe { libc::process_vm_readv(libc::getpid(), &local, 1, &remote, 1, 0) };
+    let copied = unsafe { libc::process_vm_readv(own_pid(), &local, 1, &remote, 1, 0) };
     copied == buf.len() as isize
 }
 
@@ -295,7 +349,7 @@ pub fn copy_to_guest(addr: u64, buf: &[u8]) -> bool {
         iov_base: addr as *mut libc::c_void,
         iov_len: buf.len(),
     };
-    let copied = unsafe { libc::process_vm_writev(libc::getpid(), &local, 1, &remote, 1, 0) };
+    let copied = unsafe { libc::process_vm_writev(own_pid(), &local, 1, &remote, 1, 0) };
     copied == buf.len() as isize
 }
 


### PR DESCRIPTION
The fault-safe guest copies are self-targeted process_vm_readv/writev
calls, and each one took getpid() first — a real syscall on every call,
since glibc stopped caching it in 2.25. The translator fetches its decode
window through copy_from_guest once per translated block, so a large
program pays the pair ~1.5 million times before it finishes starting
(claude translates ~744k blocks; profiling put getpid at ~0.5s of CPU).

Cache the pid in an atomic. A fork invalidates it — a stale value would
aim the copies at the parent's address space — and a forked guest arrives
via the raw clone forward, which bypasses pthread_atfork, so the runtime's
own post-fork bookkeeping (Thread::reset_after_fork) drops the cache
instead; the next copy re-reads it.

getpid drops from ~745k calls to under a thousand during claude's startup.
Render latency is unchanged — the saved CPU was spread across worker
threads, off the critical path — but the syscall count and CPU bill fall,
and the same pair no longer taxes every execve argument copy and signal
frame the runtime reads through the guest-copy seam.
