### PR TITLE
runtime: fetch the decode window through a fault-guarded memcpy

### DIFF
--- a/runtime/arch/x86/trampoline.S
+++ b/runtime/arch/x86/trampoline.S
@@ -7,6 +7,13 @@
 // does the same, but sets `exit_kind = SYSCALL` so the dispatcher knows to
 // invoke the embedder's `SystemCalls` handler before re-entering the cache.
 //
+// The file also defines `chimera_fetch_copy`, the fault-guarded copy the
+// translator fetches its decode window through. It lives here rather than in
+// Rust because its fault tolerance is an ABI contract with the fault handler:
+// the handler recognizes a fault by rip range and resumes at a fixed label,
+// which requires the faulting instruction and the fixup to sit at exported,
+// compiler-opaque addresses.
+//
 // All TS_* placeholders are field offsets into ThreadState, supplied by
 // global_asm! via offset_of!. Update the struct and the asm picks up the new
 // offsets at compile time — no magic numbers to keep in sync.
@@ -209,3 +216,31 @@ exit_trap:
     pop rbx
     ret
 .size exit_trap, . - exit_trap
+
+// fn chimera_fetch_copy(dst: *mut u8 /* rdi */, src: *const u8 /* rsi */,
+//                       len: usize /* rdx */) -> usize /* rax */
+//
+// Copy `len` bytes from an untrusted guest address to `dst`, returning how
+// many bytes were copied: `len` when the whole range is readable, the
+// byte-exact readable prefix when a fault cuts the copy short. The guarantee
+// is the kernel's exception-table pattern: a faulting `rep movsb` leaves
+// rcx/rsi/rdi reflecting exact progress, so the fault handler, on seeing a
+// rip inside [chimera_fetch_copy_start, chimera_fetch_fixup), rewrites the
+// rip to `chimera_fetch_fixup` and returns — execution resumes below the
+// copy and `len - rcx` is the count. The recognition is a rip-range compare
+// against these exported labels, so the primitive needs no per-thread arming
+// and the handler stays within its no-TLS, no-allocation contract.
+.globl chimera_fetch_copy
+.type chimera_fetch_copy, @function
+chimera_fetch_copy:
+    mov rcx, rdx
+    cld
+.globl chimera_fetch_copy_start
+chimera_fetch_copy_start:
+    rep movsb
+.globl chimera_fetch_fixup
+chimera_fetch_fixup:
+    mov rax, rdx
+    sub rax, rcx
+    ret
+.size chimera_fetch_copy, . - chimera_fetch_copy

--- a/runtime/arch/x86/trampoline.rs
+++ b/runtime/arch/x86/trampoline.rs
@@ -15,6 +15,11 @@
 //! `trampoline.S` resolves to an `offset_of!` against `ThreadState`. Update
 //! the struct and the asm picks up the new offsets at compile time — no
 //! magic numbers to keep in sync.
+//!
+//! `trampoline.S` also defines `chimera_fetch_copy`, the fault-guarded copy
+//! behind [`fetch_copy`]: the translator's per-block decode-window fetch,
+//! which must tolerate an unreadable guest address (a wild jump) without
+//! faulting the runtime.
 
 use std::{arch::global_asm, mem::offset_of};
 
@@ -59,4 +64,76 @@ unsafe extern "C" {
     pub fn exit_block();
     pub fn exit_syscall();
     pub fn exit_trap();
+    fn chimera_fetch_copy(dst: *mut u8, src: *const u8, len: usize) -> usize;
+    fn chimera_fetch_copy_start();
+    fn chimera_fetch_fixup();
+}
+
+/// Copy up to `buf.len()` bytes of guest memory at `src` into `buf` without
+/// trusting the address. A direct `rep movsb` whose fault the handler fixes
+/// up ([`fetch_copy_span`]), so the common case — every byte readable — costs
+/// a memcpy, not a syscall. Returns the byte-exact readable prefix length:
+/// `buf.len()` on a full copy, 0 when `src` itself is unreadable. Callers run
+/// only after [`crate::sys::linux::fault::install`]; without the handler an
+/// unreadable byte is a fatal fault.
+pub fn fetch_copy(src: u64, buf: &mut [u8]) -> usize {
+    unsafe { chimera_fetch_copy(buf.as_mut_ptr(), src as *const u8, buf.len()) }
+}
+
+/// Host-rip bounds `[start, fixup)` of `chimera_fetch_copy`'s faultable span.
+/// A `SIGSEGV`/`SIGBUS` whose rip lies inside resumes at `fixup`, which
+/// returns the partial count.
+pub fn fetch_copy_span() -> (usize, usize) {
+    (
+        chimera_fetch_copy_start as *const () as usize,
+        chimera_fetch_fixup as *const () as usize,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+
+    use super::*;
+
+    const PAGE: usize = 4096;
+
+    #[test]
+    fn fetch_copy_returns_readable_prefix() {
+        crate::sys::linux::fault::install();
+
+        // A readable page followed by a PROT_NONE page, so a copy can start
+        // readable and fault partway through.
+        let map = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                PAGE * 2,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(map, libc::MAP_FAILED);
+        let base = map as usize;
+        unsafe {
+            ptr::write_bytes(map as *mut u8, 0xab, PAGE);
+            let ret = libc::mprotect((base + PAGE) as *mut libc::c_void, PAGE, libc::PROT_NONE);
+            assert_eq!(ret, 0);
+        }
+
+        let mut buf = [0u8; 64];
+        assert_eq!(fetch_copy(base as u64, &mut buf), buf.len());
+        assert!(buf.iter().all(|&b| b == 0xab));
+
+        let mut buf = [0u8; 64];
+        assert_eq!(fetch_copy((base + PAGE - 24) as u64, &mut buf), 24);
+        assert!(buf[..24].iter().all(|&b| b == 0xab));
+        assert!(buf[24..].iter().all(|&b| b == 0));
+
+        let mut buf = [0u8; 64];
+        assert_eq!(fetch_copy((base + PAGE) as u64, &mut buf), 0);
+
+        unsafe { libc::munmap(map, PAGE * 2) };
+    }
 }

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -14,9 +14,9 @@ use iced_x86::{
     Instruction, InstructionBlock, MemoryOperand, OpKind, Register,
 };
 
-use crate::{Error, sys::mmap::copy_from_guest};
+use crate::Error;
 
-use super::dispatch::ThreadState;
+use super::{dispatch::ThreadState, trampoline::fetch_copy};
 
 const MAX_BLOCK_GUEST_BYTES: usize = 4096;
 /// Longest possible x86-64 instruction encoding. An instruction whose start
@@ -455,19 +455,15 @@ pub struct Translation {
 }
 
 /// Copy up to one decode window of guest bytes at `guest_pc` into `buf`,
-/// without trusting the address ([`copy_from_guest`]). Returns how many bytes
-/// are readable: the whole window, its prefix up to the page boundary when the
-/// window straddles into an unmapped page, or 0 when `guest_pc` itself is
-/// unreadable. The window is one page long, so it crosses at most one boundary.
+/// without trusting the address ([`fetch_copy`]). Returns how many bytes are
+/// readable: the whole window, its prefix up to where the window runs into
+/// unreadable memory, or 0 when `guest_pc` itself is unreadable. This runs
+/// once per translated block — over a million times while a large program
+/// starts — so it is a direct fault-guarded copy, not a `process_vm_readv`
+/// probe: W^X guarantees every page the guest can execute is host-readable,
+/// so the guarded fault path never runs except on a wild jump.
 fn read_guest_window(guest_pc: u64, buf: &mut [u8]) -> usize {
-    if copy_from_guest(guest_pc, buf) {
-        return buf.len();
-    }
-    let prefix = (buf.len() - (guest_pc as usize & (buf.len() - 1))) % buf.len();
-    if prefix != 0 && copy_from_guest(guest_pc, &mut buf[..prefix]) {
-        return prefix;
-    }
-    0
+    fetch_copy(guest_pc, buf)
 }
 
 /// Translate one basic block starting at `guest_pc`. Returns the host PC at

--- a/runtime/sys/linux/fault.rs
+++ b/runtime/sys/linux/fault.rs
@@ -13,12 +13,16 @@
 //! It owns the host `SIGSEGV`/`SIGBUS` disposition. The guest's own handlers for
 //! those are recorded in the disposition table but never installed on the host
 //! slot ([`super::signal`]), so this handler always runs first and can classify
-//! the fault. A fault that is not an SMC write — a genuine guest fault, or one
-//! taken in Chimera's own code — prints a crash report ([`report_fault`]) in the
-//! style of a kernel OOPS (cause, faulting addresses, the full guest register
-//! file, the faulting instruction's bytes, and a slice of the stack) and is then
-//! left to terminate the process with the faithful signal; precise delivery into
-//! a guest fault handler is not modeled.
+//! the fault. Besides SMC writes it recognizes one other recoverable fault, in
+//! the style of a kernel exception table: a fault whose rip lies inside the
+//! `chimera_fetch_copy` primitive — the translator probing an untrusted guest
+//! address for its decode window — resumes at the primitive's fixup label,
+//! which reports the readable prefix. A fault that is neither — a genuine guest
+//! fault, or one taken in Chimera's own code — prints a crash report
+//! ([`report_fault`]) in the style of a kernel OOPS (cause, faulting addresses,
+//! the full guest register file, the faulting instruction's bytes, and a slice
+//! of the stack) and is then left to terminate the process with the faithful
+//! signal; precise delivery into a guest fault handler is not modeled.
 //!
 //! The handler is async-signal-safe: it touches only atomics, a `Mutex` and
 //! `HashMap` whose operations never allocate, and `mprotect`. It must not call
@@ -33,7 +37,10 @@ use std::{
     },
 };
 
-use crate::{arch::x86::translate::code_cache_contains, process::Process};
+use crate::{
+    arch::x86::{trampoline::fetch_copy_span, translate::code_cache_contains},
+    process::Process,
+};
 
 /// The running guest's shared process state, published by [`set_process`] so
 /// the fault handler can reach the shared address space. A raw pointer because
@@ -82,6 +89,22 @@ extern "C" fn chimera_fault(
             libc::sigaction(signo, &sa, ptr::null_mut());
             libc::raise(signo);
         }
+        return;
+    }
+
+    // A memory fault inside the guarded guest-fetch span: the translator
+    // probed an unreadable guest address through `chimera_fetch_copy` — a
+    // wild jump, a decode window straddling into an unmapped page (SIGSEGV),
+    // or one reaching past the end of a truncated file-backed mapping
+    // (SIGBUS). Resume at the fixup label, which returns the readable prefix
+    // length to the translator. This must stay below the kill-raised check
+    // above (those must terminate regardless of the interrupted rip) and is
+    // a compare against Chimera's own .text, disjoint from the code cache
+    // and from guest pages, so it can never claim an SMC trap or a guest
+    // fault, and it needs no per-thread state.
+    let (fetch_start, fetch_fixup) = fetch_copy_span();
+    if (fetch_start..fetch_fixup).contains(&rip) {
+        set_fault_rip(ucontext, fetch_fixup);
         return;
     }
 
@@ -334,4 +357,14 @@ fn fault_rip(ucontext: *mut libc::c_void) -> usize {
     }
     let uc = ucontext as *const libc::ucontext_t;
     unsafe { (*uc).uc_mcontext.gregs[libc::REG_RIP as usize] as usize }
+}
+
+/// Write a new instruction pointer into the signal's `ucontext`; `sigreturn`
+/// resumes the interrupted thread there.
+fn set_fault_rip(ucontext: *mut libc::c_void, rip: usize) {
+    if ucontext.is_null() {
+        return;
+    }
+    let uc = ucontext as *mut libc::ucontext_t;
+    unsafe { (*uc).uc_mcontext.gregs[libc::REG_RIP as usize] = rip as libc::greg_t };
 }

--- a/runtime/sys/mmap.rs
+++ b/runtime/sys/mmap.rs
@@ -255,13 +255,11 @@ impl Drop for AddressSpace {
 
 /// The runtime's pid, cached for the self-targeted `process_vm` copies below.
 /// glibc has not cached `getpid()` since 2.25, so taking it per copy doubles
-/// each copy's syscall bill — and the translator fetches its decode window
-/// through [`copy_from_guest`] once per translated block, which for a large
-/// program is over a million syscalls before it finishes starting. A fork
-/// invalidates the value (a stale pid would aim the copies at the *parent's*
-/// address space), so Chimera registers a `pthread_atfork` child hook for host
-/// forks and still drops the cache from [`Thread::reset_after_fork`] for the
-/// guest's raw-`clone` fork path, which never runs libc's fork handlers.
+/// each copy's syscall bill. A fork invalidates the value (a stale pid would
+/// aim the copies at the *parent's* address space), so Chimera registers a
+/// `pthread_atfork` child hook for host forks and still drops the cache from
+/// [`Thread::reset_after_fork`] for the guest's raw-`clone` fork path, which
+/// never runs libc's fork handlers.
 ///
 /// [`Thread::reset_after_fork`]: crate::arch::x86::dispatch::Thread::reset_after_fork
 static CACHED_PID: AtomicI32 = AtomicI32::new(0);

--- a/testing/conformance/linux/code-at-mapping-end.c
+++ b/testing/conformance/linux/code-at-mapping-end.c
@@ -1,0 +1,38 @@
+// RUN: %cc %s -o %t && %runner %t
+//
+// Code whose last byte is the last byte of its mapping must still run: the
+// translator's fixed-size decode window straddles past the function into the
+// unmapped page, so the guarded fetch is cut short and only the readable
+// prefix reaches the decoder. A translator that demands the full window --
+// or that rounds the readable prefix wrong -- either refuses to translate
+// the block or crashes on the fetch. The function is placed so it ends
+// exactly at the mapping's end, the worst case for the window.
+
+#include <string.h>
+#include <sys/mman.h>
+
+#if defined(__x86_64__) && defined(__linux__)
+
+typedef int (*fn)(void);
+
+int main(void) {
+    long pg = 4096;
+    // Two pages, the second dropped to PROT_NONE so the readable mapping ends
+    // at a boundary the decode window is guaranteed to straddle.
+    unsigned char *code = mmap(0, pg * 2, PROT_READ | PROT_WRITE | PROT_EXEC,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (code == MAP_FAILED) return 1;
+    if (mprotect(code + pg, pg, PROT_NONE) != 0) return 2;
+
+    static const unsigned char ret42[] = {0xB8, 0x2A, 0x00, 0x00, 0x00, 0xC3}; // mov eax,42; ret
+    unsigned char *f = code + pg - sizeof ret42;
+    memcpy(f, ret42, sizeof ret42);
+    __builtin___clear_cache((char *) code, (char *) code + pg);
+
+    if (((fn) f)() != 42) return 3;
+    return 0;
+}
+
+#else
+#error "unsupported host for code-at-mapping-end test"
+#endif


### PR DESCRIPTION
The translator reads every block's decode window with a self-targeted
process_vm_readv (copy_from_guest): the kernel walks the page tables, so a
wild guest jump to an unmapped address fails the copy instead of faulting
the runtime. But that fault tolerance is the error path, and the syscall
prices it onto every fetch. Profiling claude's startup counted 875,914
window fetches with zero EFAULTs — the tolerance never fired on any real
path — while the syscall's kernel GUP walk (follow_page_pte,
vm_normal_page, __get_user_pages, plus the per-syscall SRSO thunks) ate
23.5% of all CPU for interactive bash startup and ~10% for claude. W^X
already guarantees the common case is safe: every page the guest can
execute is host-readable, because the mmap/mprotect forwarding strips
PROT_EXEC and forces PROT_READ.

Fetch through a direct rep movsb instead, with the kernel's
exception-table pattern supplying the fault tolerance. chimera_fetch_copy
(trampoline.S) copies dst/src/len and returns bytes copied; its faultable
span sits between two exported labels. When the SIGSEGV/SIGBUS handler
sees a memory fault whose rip lies inside that span, it rewrites the rip
to the fixup label and returns — a faulting rep movsb leaves rcx/rsi/rdi
reflecting exact progress, so the primitive resumes and returns the
byte-exact readable prefix. The recognition is two compares against
Chimera's own .text, disjoint from the code cache and guest pages, so it
cannot claim an SMC trap or a genuine guest fault, needs no TLS and no
arming — the handler runs with the guest's FS base loaded and must not
allocate — and sits below the kill-raised check, whose garbage si_addr
must still terminate. SIGBUS gets the same fixup: a fetch through a
truncated file-backed mapping faults with rip in the same span.

read_guest_window simplifies to one call — the old full-window-then-
page-prefix retry becomes the primitive's single-pass prefix — and its
full/partial/zero contract is unchanged, with 0 still flowing into the
unreadable-fetch guest-SIGSEGV path. The decoder's split logic already
tolerates arbitrary prefix lengths; a new conformance test pins the worst
case, a block whose last byte is the last readable byte of its mapping.
copy_from_guest/copy_to_guest stay on process_vm_readv/writev for the
cold paths (execve arguments, signal frames) that genuinely want a
checked copy without handler involvement.

process_vm_readv drops from 6,433 calls to zero for bash -c 'echo hi'
(2,311 to zero for /bin/true), and system time for 20 bash startups falls
from 0.48s to 0.18s on a debug build.
