### PR TITLE
runtime: honor the immediate of ret imm16

### DIFF
--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -542,6 +542,28 @@ pub fn translate(
 
     rewrite_rip_relative_leas(&mut instrs)?;
 
+    // A 66 operand-size prefix on a near `ret` truncates the popped rip to 16
+    // bits on Intel hardware, but iced decodes the prefixed form to the same
+    // `Retnq`/`Retnq_imm16` code as the plain one, so the return lowering in
+    // `emit_terminator` cannot see it. Catch it here, where the raw bytes are
+    // still at hand: everything before the `C3`/`C2 imm16` opcode tail is a
+    // prefix, and no legitimate 64-bit code emits a 16-bit return — reject it
+    // rather than silently lower it as a 64-bit return.
+    if matches!(term.code(), Code::Retnq | Code::Retnq_imm16) {
+        let off = (term.ip() - guest_pc) as usize;
+        let tail = if term.code() == Code::Retnq_imm16 {
+            3
+        } else {
+            1
+        };
+        if guest_bytes[off..off + term.len() - tail].contains(&0x66) {
+            return Err(Error::Translate(format!(
+                "unhandled 16-bit near return at {:#x}",
+                term.ip(),
+            )));
+        }
+    }
+
     // A block that touches FP/SIMD state or reads guest TLS (`fs:`) opens with
     // a lazy-install prologue: `dispatch` installs neither the guest's FP state
     // nor its FS base on entry, so the first block of a residency that needs
@@ -1442,8 +1464,31 @@ fn emit_terminator(
             emit_load_rax_from_gs(instrs, RBX_SLOT)?;
         }
         FlowControl::Return => {
+            // Far returns (`retf`) also pop CS; no 64-bit userspace code uses
+            // them, so reject them rather than silently mis-execute. (The
+            // 66-prefixed near forms decode to the same near-return codes and
+            // are rejected from the raw bytes in `translate`.)
+            if !matches!(t.code(), Code::Retnq | Code::Retnq_imm16) {
+                return Err(Error::Translate(format!(
+                    "unhandled return form at {:#x}: {:?}",
+                    t.ip(),
+                    t.code(),
+                )));
+            }
             emit_save_rax(instrs)?;
             emit_pop_rax(instrs)?;
+            // `ret imm16` releases imm16 more bytes of stack after popping the
+            // return address — callee-popped arguments (V8 builtins use this
+            // form). Drop them with `lea`, which, like `ret`, leaves the
+            // arithmetic flags untouched.
+            if t.code() == Code::Retnq_imm16 {
+                let imm = t.immediate16() as i64;
+                instrs.push(mkinstr(Instruction::with2(
+                    Code::Lea_r64_m,
+                    Register::RSP,
+                    MemoryOperand::with_base_displ(Register::RSP, imm),
+                ))?);
+            }
         }
         other => {
             return Err(Error::Translate(format!(

--- a/testing/conformance/abi/ret-imm.c
+++ b/testing/conformance/abi/ret-imm.c
@@ -1,0 +1,44 @@
+// RUN: %cc -O2 %s -o %t && %runner %t
+//
+// `ret imm16`: pops the return address, then releases imm16 more bytes of
+// stack — the callee-cleans-arguments convention V8's builtins use. A
+// translator that lowers it as a bare `ret` leaves the caller's stack pointer
+// short by imm16 after every such return; the drift eventually feeds a stale
+// stack slot to a later `ret` and control flies into the weeds. Like `ret`,
+// the form must not touch the arithmetic flags (an `add rsp, imm` lowering
+// would). The callee returns with `ret $16` holding ZF set; the caller checks
+// the returned value, that ZF survived, and that %rsp came back exactly where
+// it started.
+
+unsigned long call_and_check(void);
+
+__asm__(
+    ".text\n"
+    // callee_ret16(a=%rdi, b=%rsi): result in %rax, ZF set, returns with
+    // `ret $16`, releasing the two qwords its caller pushed for it.
+    "callee_ret16:\n"
+    "  lea (%rdi,%rsi), %rax\n"
+    "  cmp %rdi, %rdi\n"
+    "  ret $16\n"
+
+    // call_and_check(): pushes two qwords, calls callee_ret16, and verifies
+    // ZF is still set and %rsp is back to its pre-push value. Returns the sum
+    // on success, 0 on a flags or stack mismatch.
+    "call_and_check:\n"
+    "  mov %rsp, %r11\n"
+    "  push $2\n"
+    "  push $3\n"
+    "  mov $40, %rdi\n"
+    "  mov $2, %rsi\n"
+    "  call callee_ret16\n"
+    "  jne 1f\n"
+    "  cmp %rsp, %r11\n"
+    "  jne 1f\n"
+    "  ret\n"
+    "1:\n"
+    "  xor %eax, %eax\n"
+    "  ret\n");
+
+int main(void) {
+    return call_and_check() == 42 ? 0 : 1;
+}


### PR DESCRIPTION
The translator lowered every FlowControl::Return as a bare pop of the
return address, silently dropping the imm16 of `ret imm16` — the
callee-cleans-arguments form V8's builtins return with (`ret $0x10`).
Each such return left the guest stack short by the immediate; during
node's bootstrap the drift eventually fed Ignition's Return path an
interpreted-frame type marker (0x24) as a return address, and the wild
jump surfaced as a silent guest SIGSEGV. Any Node.js binary (and the
codex CLI, which launches through one) died within a second of startup.

Release the immediate with `lea rsp, [rsp+imm]` after the pop — `lea`
because `ret` leaves the arithmetic flags untouched and an `add` would
clobber them.

The unsupported return forms now fail translation instead of silently
mis-executing: far returns (`retf`, which also pop CS) are rejected by
code in the return lowering, and the 66-prefixed near forms (which
truncate the popped rip to 16 bits) are rejected from the raw
instruction bytes in `translate` — iced decodes them to the same
`Retnq`/`Retnq_imm16` codes as the plain forms, so the prefix is
invisible to a code match.

The new conformance test returns through `ret $16` with ZF set and
checks the returned value, the flags, and that rsp lands exactly where
it started.
