### PR TITLE
Add `chimera version` command

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -25,7 +25,21 @@ fn main() -> ExitCode {
     let opts: Opts = argh::from_env();
     match opts.command {
         Command::Run(cmd) => run(cmd),
+        Command::Version(_) => version(),
     }
+}
+
+fn version() -> ExitCode {
+    println!(
+        "chimera version {} linux x86-64 {}",
+        env!("CARGO_PKG_VERSION"),
+        if chimera::mpk_enabled() {
+            "mpk"
+        } else {
+            "nompk"
+        }
+    );
+    ExitCode::SUCCESS
 }
 
 fn run(cmd: RunCmd) -> ExitCode {

--- a/cli/opts.rs
+++ b/cli/opts.rs
@@ -16,6 +16,7 @@ pub struct Opts {
 #[argh(subcommand)]
 pub enum Command {
     Run(RunCmd),
+    Version(VersionCmd),
 }
 
 /// Run a program.
@@ -39,3 +40,8 @@ pub struct RunCmd {
     #[argh(positional)]
     pub args: Vec<String>,
 }
+
+/// Print version information.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "version")]
+pub struct VersionCmd {}

--- a/runtime/arch/mod.rs
+++ b/runtime/arch/mod.rs
@@ -13,3 +13,6 @@ pub use x86::dispatch;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86::init;
+
+#[cfg(target_arch = "x86_64")]
+pub use x86::mpk_enabled;

--- a/runtime/arch/x86/mod.rs
+++ b/runtime/arch/x86/mod.rs
@@ -13,6 +13,8 @@ pub mod dispatch;
 pub mod trampoline;
 pub mod translate;
 
+pub use translate::mpk_enabled;
+
 pub fn init() -> Result<(), Error> {
     static INIT: OnceLock<Result<(), &'static str>> = OnceLock::new();
 

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -455,13 +455,10 @@ fn acquire_pkey() -> Option<i32> {
                 {
                     continue;
                 }
-                let raw = unsafe { libc::syscall(libc::SYS_pkey_alloc, 0, 0) };
-                if raw < 0 {
+                let Some(pkey) = allocate_pkey() else {
                     CODE_CACHE_PKEY.store(PKEY_UNSUPPORTED, Ordering::Release);
-                    warn_code_cache_unguarded();
                     return None;
-                }
-                let pkey = raw as i32;
+                };
                 CODE_CACHE_PKEY.store(pkey, Ordering::Release);
                 return Some(pkey);
             }
@@ -471,16 +468,17 @@ fn acquire_pkey() -> Option<i32> {
     }
 }
 
-/// Emitted once, on the first cache built without a protection key: a guest can
-/// then rewrite already-translated code and smuggle raw host syscalls past the
-/// embedder, so the operator must know the code-cache guard is off.
-fn warn_code_cache_unguarded() {
-    eprintln!(
-        "chimera: warning: no memory protection keys on this host \
-         (no CPU PKU or CONFIG_PKEYS); the translated-code cache runs \
-         writable to the guest and the sandbox cannot stop a guest from \
-         rewriting it to bypass syscall filtering"
-    );
+fn allocate_pkey() -> Option<i32> {
+    let raw = unsafe { libc::syscall(libc::SYS_pkey_alloc, 0, 0) };
+    (raw >= 0).then_some(raw as i32)
+}
+
+pub fn mpk_enabled() -> bool {
+    let Some(pkey) = allocate_pkey() else {
+        return false;
+    };
+    unsafe { libc::syscall(libc::SYS_pkey_free, pkey) };
+    true
 }
 
 fn pkey_mprotect(

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -35,6 +35,12 @@ pub const DEFAULT_CODE_CACHE_SIZE: usize = 256 * 1024 * 1024;
 /// the cache must stay under 2 GiB for the displacement to fit in an `i32`.
 pub const MAX_CODE_CACHE_SIZE: usize = i32::MAX as usize;
 
+/// Whether the host supports memory protection keys for the translated-code
+/// cache.
+pub fn mpk_enabled() -> bool {
+    arch::mpk_enabled()
+}
+
 /// A sandboxed guest program, configured but not yet running.
 pub struct Sandbox {
     program: PathBuf,

--- a/testing/conformance/isolation/cache-poison.c
+++ b/testing/conformance/isolation/cache-poison.c
@@ -190,8 +190,8 @@ int main(void) {
     // Any bytes on the pipe are the smuggled write(2): the guest patched the
     // cache and ran a raw host syscall. That is the escape, and it is a failure
     // wherever Chimera can arm the guard -- i.e. wherever the host has
-    // protection keys. Without them Chimera cannot enforce it (and says so at
-    // startup), so the escape is out of this test's scope, not a failure.
+    // protection keys. Without them Chimera cannot enforce it, so the escape is
+    // out of this test's scope, not a failure.
     if (n > 0) {
         return host_has_pku() ? 3 : 0;
     }


### PR DESCRIPTION
Instead of priting out a notice at every `chimera run` invocation, add a `chimera version` command to print Chimera software version, hardware architecture, and memory protection key support.