### PR TITLE
Random fixes for OpenCode

### DIFF
--- a/runtime/arch/x86/cache.rs
+++ b/runtime/arch/x86/cache.rs
@@ -8,6 +8,17 @@
 //! branch graph. Linking keeps a chain of blocks running back-to-back inside a
 //! single `dispatch()` call instead of round-tripping through the run loop at
 //! every basic-block boundary.
+//!
+//! Sibling threads execute out of the cache the whole time this bookkeeping
+//! runs, so every mutation of reachable code is a single aligned atomic store
+//! into a `rel32` field ([`patch_site`]) — a branch is re-aimed, but no
+//! instruction bytes are ever spliced. Invalidation severs a dropped block's
+//! incoming edges the same way, re-aiming each one back at its own cold exit
+//! stub; the dropped block's body is left intact (cache memory is never reused
+//! short of [`BlockCache::reset`]), so a thread already in flight through a
+//! stale edge executes one intact pre-invalidation block and re-resolves at
+//! its next boundary — the same staleness a native core sees when it executes
+//! prefetched bytes an instant before a cross-modifying write lands.
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -23,21 +34,21 @@ use super::translate::{CodeCache, OutEdge, Translation, translate};
 /// touches it.
 const PAGE: u64 = 4096;
 
-/// One translated block's bookkeeping: where its host code begins and the
-/// address of its deopt stub (used to neutralize the block on invalidation).
-#[derive(Clone, Copy)]
-struct Block {
-    host: u64,
-    deopt: u64,
+/// One direct-branch link site: the address of a patchable `rel32` field and
+/// the address of the cold exit stub the field targets while its edge is
+/// unlinked.
+struct LinkSite {
+    site: usize,
+    stub: u64,
 }
 
-/// The translated-block cache: the host code buffer, the guest-PC → block map,
-/// the page → blocks index that drives SMC invalidation, and the pending
-/// direct-branch links awaiting their successors.
+/// The translated-block cache: the host code buffer, the guest-PC → host-PC
+/// map, the page → blocks index that drives SMC invalidation, and the link
+/// registry that records every direct branch by successor.
 pub struct BlockCache {
     cache: CodeCache,
-    /// Guest block PC -> the block translated there.
-    map: HashMap<u64, Block>,
+    /// Guest block PC -> its host entry.
+    map: HashMap<u64, u64>,
     /// Guest page base -> start PCs of the blocks whose code touches that page,
     /// so a write to the page can find and drop them. A block spanning two pages
     /// is listed under both; stale entries (a block already dropped) are skipped
@@ -45,11 +56,17 @@ pub struct BlockCache {
     /// `BTreeMap` so [`invalidate_range`] can drop a span of pages without
     /// walking the whole index — a guest `munmap`/`mprotect` may cover gigabytes.
     page_blocks: BTreeMap<u64, Vec<u64>>,
-    /// Direct branches awaiting their successor: guest target PC -> addresses
-    /// of the `rel32` displacement fields to rewrite once that block exists.
-    /// An edge whose target is already translated is patched on the spot and
-    /// never lands here. Drained in [`BlockCache::resolve`].
-    pending: HashMap<u64, Vec<usize>>,
+    /// Successor guest PC -> every direct-branch site that targets it, live for
+    /// the lifetime of the cache. A site is aimed at the successor's host entry
+    /// exactly while that guest PC is in `map`, and at its own cold exit stub
+    /// otherwise: translation patches the list toward the new entry, and
+    /// invalidation patches it back ([`invalidate_page`] runs inside the
+    /// synchronous fault handler, so severing edges must not allocate — it only
+    /// walks this list and stores). Sites inside blocks that have themselves
+    /// been dropped linger here; re-aiming them writes into cache bytes nothing
+    /// jumps to any more, which is harmless, and they are shed only at
+    /// [`reset`].
+    links: HashMap<u64, Vec<LinkSite>>,
 }
 
 impl BlockCache {
@@ -58,7 +75,7 @@ impl BlockCache {
             cache: CodeCache::new(cache_size)?,
             map: HashMap::new(),
             page_blocks: BTreeMap::new(),
-            pending: HashMap::new(),
+            links: HashMap::new(),
         })
     }
 
@@ -68,10 +85,11 @@ impl BlockCache {
     /// returns `None` for the span.
     ///
     /// On a translation, the new block is linked into the cache's branch graph:
-    /// any direct branches that were waiting for this guest PC are patched to
-    /// jump straight here, and the new block's own outgoing direct branches are
-    /// either patched to their (already-translated) successors or recorded as
-    /// pending. After warm-up, chains of linked blocks execute back-to-back
+    /// every direct branch registered for this guest PC — waiting since its own
+    /// translation, or severed by an earlier invalidation — is patched to jump
+    /// straight here, and the new block's own outgoing direct branches are
+    /// registered under their successors and patched to any that are already
+    /// translated. After warm-up, chains of linked blocks execute back-to-back
     /// without returning to the dispatcher.
     pub fn resolve(
         &mut self,
@@ -80,17 +98,16 @@ impl BlockCache {
         syscall_exit: u64,
         trap_exit: u64,
     ) -> Result<(u64, Option<(u64, u64)>), Error> {
-        if let Some(&block) = self.map.get(&guest_pc) {
+        if let Some(&host) = self.map.get(&guest_pc) {
             // Refresh the in-cache lookup entry: reaching here means an indirect
             // branch missed it (a direct-mapped collision evicted it), so
             // reinstate it to return the hot target to the fast path.
-            self.cache.ib_insert(guest_pc, block.host);
-            return Ok((block.host, None));
+            self.cache.ib_insert(guest_pc, host);
+            return Ok((host, None));
         }
         let Translation {
             host_pc,
             guest_end,
-            deopt_pc,
             edges,
         } = translate(
             &mut self.cache,
@@ -99,13 +116,7 @@ impl BlockCache {
             syscall_exit,
             trap_exit,
         )?;
-        self.map.insert(
-            guest_pc,
-            Block {
-                host: host_pc,
-                deopt: deopt_pc,
-            },
-        );
+        self.map.insert(guest_pc, host_pc);
         // Index the block under every guest page it touches.
         let mut page = guest_pc & !(PAGE - 1);
         let last = guest_end.saturating_sub(1) & !(PAGE - 1);
@@ -119,36 +130,46 @@ impl BlockCache {
         // Mirror the mapping into the in-cache lookup table so indirect
         // branches to this block resolve without leaving the cache.
         self.cache.ib_insert(guest_pc, host_pc);
-        if let Some(sites) = self.pending.remove(&guest_pc) {
-            for site in sites {
-                patch_site(site, host_pc);
+        if let Some(sites) = self.links.get(&guest_pc) {
+            for s in sites {
+                patch_site(s.site, host_pc);
             }
         }
-        for OutEdge { target_guest, site } in edges {
-            match self.map.get(&target_guest) {
-                Some(&target) => patch_site(site, target.host),
-                None => self.pending.entry(target_guest).or_default().push(site),
+        for OutEdge {
+            target_guest,
+            site,
+            stub,
+        } in edges
+        {
+            if let Some(&target) = self.map.get(&target_guest) {
+                patch_site(site, target);
             }
+            self.links
+                .entry(target_guest)
+                .or_default()
+                .push(LinkSite { site, stub });
         }
         Ok((host_pc, Some((guest_pc, guest_end))))
     }
 
     /// Drop every block whose code touches guest `page`, for self-modifying
     /// code: each is removed from the map, evicted from the indirect-branch
-    /// table, and its host entry redirected to its deopt stub so any surviving
-    /// direct link into it re-translates. Returns whether anything was dropped.
+    /// table, and severed from the branch graph — every direct branch linked to
+    /// it is re-aimed at its own cold exit stub, so the next traversal of the
+    /// edge falls back to the dispatcher and re-translates from current guest
+    /// memory. Returns whether anything was dropped.
     ///
     /// Allocation-free: it runs inside the synchronous fault handler, so it must
     /// not call the allocator. The page's block list is cleared in place
-    /// (retaining its buffer) rather than removed, and `HashMap::remove` neither
-    /// shrinks nor frees.
+    /// (retaining its buffer) rather than removed, `HashMap::remove` neither
+    /// shrinks nor frees, and unlinking only walks `links` and stores.
     pub fn invalidate_page(&mut self, page: u64) -> bool {
         let mut dropped = false;
         if let Some(starts) = self.page_blocks.get_mut(&page) {
             for &guest_pc in starts.iter() {
-                if let Some(block) = self.map.remove(&guest_pc) {
+                if self.map.remove(&guest_pc).is_some() {
                     self.cache.ib_remove(guest_pc);
-                    self.cache.neutralize(block.host, block.deopt);
+                    unlink(&self.links, guest_pc);
                     dropped = true;
                 }
             }
@@ -165,9 +186,9 @@ impl BlockCache {
     pub fn invalidate_range(&mut self, lo_page: u64, hi_page: u64) {
         for (_, starts) in self.page_blocks.range_mut(lo_page..=hi_page) {
             for &guest_pc in starts.iter() {
-                if let Some(block) = self.map.remove(&guest_pc) {
+                if self.map.remove(&guest_pc).is_some() {
                     self.cache.ib_remove(guest_pc);
-                    self.cache.neutralize(block.host, block.deopt);
+                    unlink(&self.links, guest_pc);
                 }
             }
             starts.clear();
@@ -181,13 +202,24 @@ impl BlockCache {
     }
 
     /// Flush every translated block and its link bookkeeping. The backing code
-    /// buffer is rewound; the guest-PC map, page index, and pending links are
+    /// buffer is rewound; the guest-PC map, page index, and link registry are
     /// cleared.
     pub fn reset(&mut self) {
         self.cache.reset();
         self.map.clear();
         self.page_blocks.clear();
-        self.pending.clear();
+        self.links.clear();
+    }
+}
+
+/// Sever every direct branch targeting `guest_pc` by re-aiming its `rel32`
+/// back at its own cold exit stub — the reverse of the linking in
+/// [`BlockCache::resolve`], and the same single atomic store.
+fn unlink(links: &HashMap<u64, Vec<LinkSite>>, guest_pc: u64) {
+    if let Some(sites) = links.get(&guest_pc) {
+        for s in sites {
+            patch_site(s.site, s.stub);
+        }
     }
 }
 
@@ -196,11 +228,12 @@ impl BlockCache {
 /// the end of its own four bytes. The cache stays well under 2 GiB, so the
 /// signed distance always fits in an `i32`.
 ///
-/// The translator aligns every patchable `rel32` field to a 4-byte boundary
-/// (see `build_linked_terminator`), so this is a single aligned atomic store:
-/// a sibling thread executing the branch reads either the old target (its cold
-/// exit stub, which round-trips through the dispatcher) or the new one, never a
-/// torn displacement spliced from both. x86 keeps instruction and data caches
+/// The translator places every patchable `rel32` field on a 4-byte boundary
+/// that keeps the whole branch instruction inside one aligned 16-byte fetch
+/// window (see `pad_rel32_alignment`), so this single aligned atomic store is
+/// indivisible for a sibling thread's instruction fetch as well: the sibling
+/// executes the branch toward the old target or the new one, never a torn
+/// displacement spliced from both. x86 keeps instruction and data caches
 /// coherent, so the executing core picks up the new target on its next fetch.
 fn patch_site(site: usize, host_pc: u64) {
     let disp = host_pc as i64 - (site as i64 + 4);
@@ -209,8 +242,8 @@ fn patch_site(site: usize, host_pc: u64) {
         "link displacement {disp} out of rel32 range"
     );
     debug_assert!(
-        site.is_multiple_of(4),
-        "link site {site:#x} is not 4-byte aligned"
+        site.is_multiple_of(4) && !site.is_multiple_of(16),
+        "link site {site:#x} straddles a fetch window"
     );
     let slot = unsafe { &*(site as *const AtomicI32) };
     slot.store(disp as i32, Ordering::Release);

--- a/runtime/arch/x86/dispatch.rs
+++ b/runtime/arch/x86/dispatch.rs
@@ -161,6 +161,7 @@ impl Thread {
                 fs_is_guest: 0,
                 pending_set: 0,
                 tid: AtomicI32::new(0),
+                riprel_scratch: 0,
             }),
             process,
             signals,
@@ -860,6 +861,12 @@ pub struct ThreadState {
     /// signal. Atomic because those reads are cross-thread; placed after
     /// `fpstate` so every `gs:[]` offset above is unchanged.
     pub tid: AtomicI32,
+    /// Save slot for the register a far-RIP-relative rewrite borrows to
+    /// materialize an absolute guest address (see `rewrite_far_rip_operand` in
+    /// the translator). Live only across the few instructions of one rewritten
+    /// guest instruction, always within a block body; placed after `fpstate`
+    /// so every `gs:[]` offset above is unchanged.
+    pub riprel_scratch: u64,
 }
 
 // XSAVE/XRSTOR #GP unless the save area is 64-byte aligned. The struct's
@@ -886,6 +893,7 @@ impl ThreadState {
         self.ib_rcx = 0;
         self.ib_rdx = 0;
         self.ib_host = 0;
+        self.riprel_scratch = 0;
         self.exit_requested.store(0, Ordering::Relaxed);
         self.fp_in_regs = 0;
         self.fp_flags = 0;
@@ -948,6 +956,7 @@ impl ThreadState {
             // Cleared for the same reason as the run-entry store: the child
             // publishes its own TID before it runs any guest code.
             tid: AtomicI32::new(0),
+            riprel_scratch: 0,
         });
         child.regs[RAX] = 0;
         child.regs[RSP] = child_stack;

--- a/runtime/arch/x86/trampoline.S
+++ b/runtime/arch/x86/trampoline.S
@@ -281,3 +281,26 @@ chimera_fetch_fixup:
     sub rax, rcx
     ret
 .size chimera_fetch_copy, . - chimera_fetch_copy
+// fn guarded_copy(dst: *mut u8 /* rdi */, src: *const u8 /* rsi */,
+//                 len: usize /* rdx */) -> i64
+//
+// Copy `len` bytes from unvalidated guest memory with plain loads — the
+// kernel's `copy_from_user` exception-table pattern, in miniature. The fault
+// handler recovers a `SIGSEGV`/`SIGBUS` whose rip lies inside this routine by
+// redirecting the interrupted thread to `guarded_copy_fault`, which reports
+// the failed copy. Returns 1 on a complete copy, 0 on a fault; a faulted copy
+// may have written any readable prefix of `dst`.
+.globl guarded_copy
+.type guarded_copy, @function
+guarded_copy:
+    mov rcx, rdx
+    rep movsb
+    mov eax, 1
+    ret
+.globl guarded_copy_fault
+guarded_copy_fault:
+    xor eax, eax
+    ret
+.size guarded_copy, . - guarded_copy
+.globl guarded_copy_end
+guarded_copy_end:

--- a/runtime/arch/x86/trampoline.rs
+++ b/runtime/arch/x86/trampoline.rs
@@ -68,6 +68,9 @@ unsafe extern "C" {
     fn chimera_fetch_copy(dst: *mut u8, src: *const u8, len: usize) -> usize;
     fn chimera_fetch_copy_start();
     fn chimera_fetch_fixup();
+    pub fn guarded_copy(dst: *mut u8, src: *const u8, len: usize) -> i64;
+    fn guarded_copy_fault();
+    fn guarded_copy_end();
 }
 
 /// Copy up to `buf.len()` bytes of guest memory at `src` into `buf` without
@@ -89,6 +92,20 @@ pub fn fetch_copy_span() -> (usize, usize) {
         chimera_fetch_copy_start as *const () as usize,
         chimera_fetch_fixup as *const () as usize,
     )
+}
+
+/// Whether `rip` lies inside [`guarded_copy`], so a fault taken there is a
+/// failed read of guest memory rather than a crash in Chimera.
+pub fn in_guarded_copy(rip: usize) -> bool {
+    let lo = guarded_copy as *const () as usize;
+    let hi = guarded_copy_end as *const () as usize;
+    (lo..hi).contains(&rip)
+}
+
+/// Where the fault handler resumes a faulted [`guarded_copy`]: the routine's
+/// failure tail, which returns 0 to the caller.
+pub fn guarded_copy_fixup() -> usize {
+    guarded_copy_fault as *const () as usize
 }
 
 #[cfg(test)]

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -771,10 +771,121 @@ fn emit_body(
     if instrs.is_empty() {
         return Ok(());
     }
+    let rewritten = rewrite_far_rip_operands(instrs, host_pc)?;
+    let instrs = rewritten.as_deref().unwrap_or(instrs);
     let block = InstructionBlock::new(instrs, host_pc);
     let result = BlockEncoder::encode(64, block, BlockEncoderOptions::NONE)
         .map_err(|e| Error::Translate(format!("encode block at {:#x}: {}", guest_pc, e)))?;
     cache.emit(&result.code_buffer)
+}
+
+/// Slack subtracted from the `rel32` range when deciding whether a RIP-relative
+/// target is still reachable once the instruction moves into the code cache. The
+/// displacement is measured from the instruction's own position within the
+/// encoded block, not from `host_pc`, and an encoded block is bounded far below
+/// this (a block decodes at most [`MAX_BLOCK_GUEST_BYTES`] guest bytes).
+const RIP_REACH_SLACK: u64 = 1 << 20;
+
+fn rip_reachable(target: u64, host_pc: u64) -> bool {
+    let disp = target as i128 - host_pc as i128;
+    disp.unsigned_abs() < (i32::MAX as u64 - RIP_REACH_SLACK) as u128
+}
+
+/// Rewrite every RIP-relative memory operand whose effective address is out of
+/// `rel32` range of the block's spot in the code cache — guest code mapped tens
+/// of terabytes from the cache, such as a JIT region JavaScriptCore places at a
+/// randomized high address. `BlockEncoder` preserves a RIP-relative operand's
+/// effective address by adjusting its displacement, which fails outright for
+/// such a target, so the access is re-expressed through a borrowed register
+/// instead: stash the register in the `riprel_scratch` slot, materialize the
+/// absolute guest address, run the original instruction with the register as
+/// its base, and reload the register. None of the inserted `mov`s touch the
+/// arithmetic flags, so flags stay live from the block's body into its
+/// terminator, and the borrowed register's guest value is unreachable only
+/// within the sequence itself: an SMC write fault inside it resumes at the
+/// faulting store with all host registers intact, and any other fault there is
+/// terminal.
+///
+/// Returns `None` when every operand is in range, which is every block outside
+/// such far regions, so the common path encodes the original list untouched.
+fn rewrite_far_rip_operands(
+    instrs: &[Instruction],
+    host_pc: u64,
+) -> Result<Option<Vec<Instruction>>, Error> {
+    let far = |i: &Instruction| {
+        i.is_ip_rel_memory_operand() && !rip_reachable(i.ip_rel_memory_address(), host_pc)
+    };
+    if !instrs.iter().any(far) {
+        return Ok(None);
+    }
+    let slot = offset_of!(ThreadState, riprel_scratch) as i64;
+    let mut info_factory = InstructionInfoFactory::new();
+    let mut out = Vec::with_capacity(instrs.len() + 3);
+    for instr in instrs {
+        if !far(instr) {
+            out.push(*instr);
+            continue;
+        }
+        let scratch = pick_scratch(&mut info_factory, instr)?;
+        let target = instr.ip_rel_memory_address();
+        out.push(mkinstr(Instruction::with2(
+            Code::Mov_rm64_r64,
+            gs_qword(slot),
+            scratch,
+        ))?);
+        out.push(mkinstr(Instruction::with2(
+            Code::Mov_r64_imm64,
+            scratch,
+            target,
+        ))?);
+        let mut patched = *instr;
+        patched.set_memory_base(scratch);
+        patched.set_memory_displacement64(0);
+        patched.set_memory_displ_size(0);
+        out.push(patched);
+        out.push(mkinstr(Instruction::with2(
+            Code::Mov_r64_rm64,
+            scratch,
+            gs_qword(slot),
+        ))?);
+    }
+    Ok(Some(out))
+}
+
+/// Pick a register the far-RIP rewrite can borrow around `instr`: any GPR the
+/// instruction neither reads nor writes, explicitly or implicitly (`mul m64`
+/// consumes rax and rdx with no visible register operand). rsp is never a
+/// candidate — the host fault handler runs on whatever stack rsp names — and
+/// rbp/r13 are skipped so the zero-displacement base encodes uniformly. An
+/// instruction has at most a handful of register operands, so the eight
+/// candidates cannot all be taken.
+fn pick_scratch(
+    info_factory: &mut InstructionInfoFactory,
+    instr: &Instruction,
+) -> Result<Register, Error> {
+    const CANDIDATES: [Register; 8] = [
+        Register::RAX,
+        Register::RCX,
+        Register::RDX,
+        Register::RBX,
+        Register::RSI,
+        Register::RDI,
+        Register::R8,
+        Register::R9,
+    ];
+    let info = info_factory.info(instr);
+    let free = |c: &Register| {
+        !info
+            .used_registers()
+            .iter()
+            .any(|u| u.register().full_register() == *c)
+    };
+    CANDIDATES.iter().find(|c| free(c)).copied().ok_or_else(|| {
+        Error::Translate(format!(
+            "no scratch register for far RIP-relative operand at {:#x}",
+            instr.ip()
+        ))
+    })
 }
 
 /// `gs:[]` displacement of the guest's rax slot (`regs[0]`); cold exit stubs
@@ -1773,5 +1884,76 @@ mod tests {
         let key = unsafe { (cache.ib_table.add(slot) as *const u64).read() };
         assert_ne!(key, u64::MAX);
         assert_ne!(ib_slot(key), ib_slot(u64::MAX));
+    }
+}
+
+#[cfg(test)]
+mod riprel_tests {
+    use super::*;
+
+    fn decode_at(bytes: &[u8], ip: u64) -> Instruction {
+        Decoder::with_ip(64, bytes, ip, DecoderOptions::NONE).decode()
+    }
+
+    /// A RIP-relative operand within `rel32` reach of the cache is left to the
+    /// encoder's ordinary fixup: no rewrite, no inserted instructions.
+    #[test]
+    fn near_rip_operand_is_untouched() {
+        // addq $0x1e, 0x1e00(%rip)
+        let instr = decode_at(
+            &[0x48, 0x83, 0x05, 0x00, 0x1e, 0x00, 0x00, 0x1e],
+            0x7f0000001000,
+        );
+        assert!(instr.is_ip_rel_memory_operand());
+        assert!(
+            rewrite_far_rip_operands(&[instr], 0x7f0012340000)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// A far RIP-relative operand becomes the borrow sequence — save scratch,
+    /// materialize the absolute target, run the access `[scratch]`-based,
+    /// reload scratch — and the result must actually encode from the cache
+    /// address the original operand could not reach.
+    #[test]
+    fn far_rip_operand_is_rewritten_and_encodes() {
+        // addq $0x1e, 0x1e00(%rip) linked tens of terabytes from the cache.
+        let instr = decode_at(
+            &[0x48, 0x83, 0x05, 0x00, 0x1e, 0x00, 0x00, 0x1e],
+            0x35f50000200,
+        );
+        let target = instr.ip_rel_memory_address();
+        let host_pc = 0x7f0012340000u64;
+        let out = rewrite_far_rip_operands(&[instr], host_pc)
+            .unwrap()
+            .unwrap();
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[1].code(), Code::Mov_r64_imm64);
+        assert_eq!(out[1].immediate64(), target);
+        let scratch = out[1].op0_register();
+        assert_eq!(out[2].code(), Code::Add_rm64_imm8);
+        assert_eq!(out[2].memory_base(), scratch);
+        assert!(!out[2].is_ip_rel_memory_operand());
+        BlockEncoder::encode(
+            64,
+            InstructionBlock::new(&out, host_pc),
+            BlockEncoderOptions::NONE,
+        )
+        .expect("rewritten block must encode");
+    }
+
+    /// The borrowed register must not collide with any register the
+    /// instruction touches, including implicit uses: `mul qword [rip+d]`
+    /// names no register operand yet consumes rax and rdx.
+    #[test]
+    fn scratch_avoids_implicit_registers() {
+        // mulq 0x1e00(%rip)
+        let instr = decode_at(&[0x48, 0xf7, 0x25, 0x00, 0x1e, 0x00, 0x00], 0x35f50000200);
+        let out = rewrite_far_rip_operands(&[instr], 0x7f0012340000)
+            .unwrap()
+            .unwrap();
+        let scratch = out[1].op0_register();
+        assert!(!matches!(scratch, Register::RAX | Register::RDX));
     }
 }

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -231,33 +231,6 @@ impl CodeCache {
         }
     }
 
-    /// Redirect a block's host entry to its deopt stub by overwriting the first
-    /// 5 bytes at `host_pc` with `jmp rel32 -> deopt_pc`. Called when the guest
-    /// modifies the page the block was translated from: the block is dropped
-    /// from the map, and any direct branch still linked to it now lands on the
-    /// stub, which exits to the dispatcher and re-translates from current guest
-    /// memory. Relies on JIT discipline — the guest stops every thread before
-    /// rewriting code it might be running — so no sibling executes this block
-    /// while it is patched. The `jmp` opcode is published last, so a reader that
-    /// somehow raced would see the original instruction until the redirect is
-    /// fully formed rather than a spliced one.
-    pub fn neutralize(&self, host_pc: u64, deopt_pc: u64) {
-        let rel = deopt_pc as i64 - (host_pc as i64 + 5);
-        debug_assert!(
-            i32::try_from(rel).is_ok(),
-            "deopt displacement {rel} out of rel32 range"
-        );
-        let rel = rel as i32 as u32;
-        unsafe {
-            let p = host_pc as *mut u8;
-            ptr::write_volatile(p.add(1), rel as u8);
-            ptr::write_volatile(p.add(2), (rel >> 8) as u8);
-            ptr::write_volatile(p.add(3), (rel >> 16) as u8);
-            ptr::write_volatile(p.add(4), (rel >> 24) as u8);
-            ptr::write_volatile(p, 0xE9);
-        }
-    }
-
     /// Drop `guest_pc` from the inline indirect-branch table if it currently
     /// holds the slot, so a later indirect branch to it misses and re-resolves
     /// through the dispatcher (where the block has been dropped and re-translates
@@ -432,26 +405,27 @@ fn gs_qword(disp: i64) -> MemoryOperand {
 }
 
 /// A patchable outgoing edge of a translated block: the guest PC of a
-/// statically known successor, and the address of the `rel32` displacement
-/// field of the direct branch that currently targets the block's cold exit
-/// stub. Once the successor is translated, the dispatcher rewrites the
-/// displacement so the branch jumps straight into the successor's host code,
-/// keeping the guest register file live across the edge instead of
-/// round-tripping through the dispatcher. See [`super::super::sys::mmap`].
+/// statically known successor, the address of the `rel32` displacement field
+/// of the direct branch that currently targets the block's cold exit stub, and
+/// the address of that stub. Once the successor is translated, the dispatcher
+/// rewrites the displacement so the branch jumps straight into the successor's
+/// host code, keeping the guest register file live across the edge instead of
+/// round-tripping through the dispatcher; when the successor is invalidated,
+/// the dispatcher rewrites it back to `stub`, severing the edge with the same
+/// single atomic store. See [`super::super::sys::mmap`].
 pub struct OutEdge {
     pub target_guest: u64,
     pub site: usize,
+    pub stub: u64,
 }
 
 /// The result of translating one basic block: where its host code begins, the
 /// guest PC one past its last decoded byte (so the cache knows which guest pages
-/// the block covers, for self-modifying-code invalidation), the address of its
-/// deopt stub (see [`CodeCache::neutralize`]), and its statically known outgoing
-/// edges for the dispatcher to link.
+/// the block covers, for self-modifying-code invalidation), and its statically
+/// known outgoing edges for the dispatcher to link.
 pub struct Translation {
     pub host_pc: u64,
     pub guest_end: u64,
-    pub deopt_pc: u64,
     pub edges: Vec<OutEdge>,
 }
 
@@ -596,9 +570,10 @@ pub fn translate(
         cache.emit(&bytes)?;
         rel_edges
             .into_iter()
-            .map(|(off, target_guest)| OutEdge {
+            .map(|(off, stub_off, target_guest)| OutEdge {
                 target_guest,
                 site: term_pc + off,
+                stub: (term_pc + stub_off) as u64,
             })
             .collect()
     } else {
@@ -607,20 +582,9 @@ pub fn translate(
         Vec::new()
     };
 
-    // A per-block deopt stub: it saves rax, publishes this block's own guest PC
-    // into the rip slot, and exits to the dispatcher. SMC invalidation overwrites
-    // the block's host entry with a 5-byte jump to this stub, so any surviving
-    // direct link into the dropped block falls back to the dispatcher and
-    // re-translates from current guest memory (see [`CodeCache::neutralize`]).
-    let deopt_pc = cache.next_pc();
-    let mut stub = Vec::new();
-    emit_stub(&mut stub, guest_pc, exit_tramp);
-    cache.emit(&stub)?;
-
     Ok(Translation {
         host_pc,
         guest_end,
-        deopt_pc,
         edges,
     })
 }
@@ -1027,10 +991,11 @@ fn emit_exit_poll(out: &mut Vec<u8>) -> usize {
 
 /// Build the raw machine code for a linkable terminator: a fast-path direct
 /// branch followed by one cold exit stub per successor. Returns the encoded
-/// bytes and, for each edge, the byte offset of its fast-path `rel32`
-/// displacement paired with the successor's guest PC. The displacements are
-/// initialized to target the stubs; the dispatcher rewrites them to the
-/// successor blocks as those are translated.
+/// bytes and, for each edge, the byte offsets of its fast-path `rel32`
+/// displacement and of its cold exit stub, paired with the successor's guest
+/// PC. The displacements are initialized to target the stubs; the dispatcher
+/// rewrites them to the successor blocks as those are translated, and back to
+/// the stubs when a successor is invalidated.
 ///
 /// A back-edge ([`is_back_edge`]) is preceded by a safepoint poll
 /// ([`emit_exit_poll`]) that diverts to the edge's own cold-exit stub when an
@@ -1048,7 +1013,7 @@ fn build_linked_terminator(
     exit_tramp: u64,
     block_start: u64,
     term_pc: usize,
-) -> (Vec<u8>, Vec<(usize, u64)>) {
+) -> (Vec<u8>, Vec<(usize, usize, u64)>) {
     let mut out = Vec::new();
     let mut edges = Vec::new();
     match *link {
@@ -1067,7 +1032,7 @@ fn build_linked_terminator(
             if let Some(poll_rel) = poll {
                 write_rel32(&mut out, poll_rel, stub);
             }
-            edges.push((rel, target));
+            edges.push((rel, stub, target));
         }
         LinkTerm::Cond {
             opcode,
@@ -1101,8 +1066,8 @@ fn build_linked_terminator(
                 write_rel32(&mut out, jmp_rel, fall_stub);
                 write_rel32(&mut out, taken_jmp_rel, taken_stub);
                 write_rel32(&mut out, poll_rel, taken_stub);
-                edges.push((taken_jmp_rel, taken));
-                edges.push((jmp_rel, fallthrough));
+                edges.push((taken_jmp_rel, taken_stub, taken));
+                edges.push((jmp_rel, fall_stub, fallthrough));
             } else {
                 // jcc rel32 -> taken stub ; jmp rel32 -> fall-through stub.
                 // The native jcc reads the block's live guest flags directly. Each
@@ -1119,8 +1084,8 @@ fn build_linked_terminator(
                 emit_stub(&mut out, fallthrough, exit_tramp);
                 write_rel32(&mut out, jcc_rel, taken_stub);
                 write_rel32(&mut out, jmp_rel, fall_stub);
-                edges.push((jcc_rel, taken));
-                edges.push((jmp_rel, fallthrough));
+                edges.push((jcc_rel, taken_stub, taken));
+                edges.push((jmp_rel, fall_stub, fallthrough));
             }
         }
         LinkTerm::ShortCond {
@@ -1167,8 +1132,8 @@ fn build_linked_terminator(
             if let Some(poll_rel) = poll {
                 write_rel32(&mut out, poll_rel, taken_stub);
             }
-            edges.push((taken_rel, taken));
-            edges.push((fall_rel, fallthrough));
+            edges.push((taken_rel, taken_stub, taken));
+            edges.push((fall_rel, fall_stub, fallthrough));
         }
         LinkTerm::DirectCall { target, ret } => {
             // Push the 64-bit return address with a single 8-byte store so the
@@ -1203,7 +1168,7 @@ fn build_linked_terminator(
             if let Some(poll_rel) = poll {
                 write_rel32(&mut out, poll_rel, stub);
             }
-            edges.push((rel, target));
+            edges.push((rel, stub, target));
         }
     }
     (out, edges)
@@ -1393,12 +1358,25 @@ fn take_rel32(out: &mut Vec<u8>) -> usize {
 }
 
 /// Pad `out` with single-byte NOPs until the `rel32` field that will follow
-/// `opcode_len` opcode bytes lands on a 4-byte boundary in the cache, given the
-/// terminator will be emitted at `term_pc`. A naturally aligned `rel32` can be
-/// back-patched with a single atomic 32-bit store, so a sibling thread executing
-/// the branch sees the old displacement or the new one but never a torn mix.
+/// `opcode_len` opcode bytes lands on a 4-byte boundary in the cache — but not
+/// a 16-byte one — given the terminator will be emitted at `term_pc`.
+///
+/// The 4-byte alignment lets the field be back-patched with a single atomic
+/// 32-bit store; that alone, though, only makes the *store* indivisible. A
+/// sibling core's instruction fetch is not an atomic 4-byte load: it decodes
+/// from aligned 16-byte fetch windows, and a branch whose opcode sits at the
+/// end of one window with its displacement in the next can pair a stale opcode
+/// fetch with a fresh displacement fetch (or half of each) — a spliced branch
+/// that lands mid-instruction. Keeping the field off 16-byte boundaries puts
+/// the whole instruction — opcode (1 or 2 bytes, so field offsets 4, 8, and 12
+/// all work) plus displacement — inside one fetch window, so any single fetch
+/// observes the branch either entirely old or entirely new.
 fn pad_rel32_alignment(out: &mut Vec<u8>, term_pc: usize, opcode_len: usize) {
-    while !(term_pc + out.len() + opcode_len).is_multiple_of(4) {
+    loop {
+        let rel = term_pc + out.len() + opcode_len;
+        if rel.is_multiple_of(4) && !rel.is_multiple_of(16) {
+            break;
+        }
         out.push(0x90); // nop
     }
 }
@@ -1793,26 +1771,38 @@ mod tests {
     use super::*;
 
     /// Every patchable `rel32` field of a linked terminator must land on a
-    /// 4-byte boundary, whatever address the terminator is emitted at, so the
-    /// dispatcher can back-patch it with one aligned atomic store. Check all
-    /// eight residues of `term_pc` mod 4 so the padding is exercised for every
+    /// 4-byte boundary — but off 16-byte ones, so the whole branch instruction
+    /// sits inside one aligned 16-byte fetch window — whatever address the
+    /// terminator is emitted at, so the dispatcher can back-patch it with one
+    /// store that is atomic for a sibling's instruction fetch too. Check every
+    /// residue of `term_pc` mod 16 so the padding is exercised for every
     /// starting alignment.
     fn assert_edges_aligned(link: &LinkTerm) {
-        for term_pc in 0..8usize {
+        for term_pc in 0..16usize {
             // block_start 0: every target here is a forward edge (no safepoint
             // poll), exercising the bare linked-terminator alignment.
             let (bytes, edges) = build_linked_terminator(link, 0xdead_beef, 0, term_pc);
             assert!(!edges.is_empty(), "a linked terminator must expose an edge");
-            for (off, _target) in edges {
+            for (off, stub, _target) in edges {
                 assert!(
                     off + 4 <= bytes.len(),
                     "rel32 field at off={off} runs past the {} terminator bytes",
+                    bytes.len(),
+                );
+                assert!(
+                    stub <= bytes.len(),
+                    "stub at off={stub} lies past the {} terminator bytes",
                     bytes.len(),
                 );
                 assert_eq!(
                     (term_pc + off) % 4,
                     0,
                     "rel32 field at term_pc={term_pc}, off={off} is not 4-byte aligned",
+                );
+                assert_ne!(
+                    (term_pc + off) % 16,
+                    0,
+                    "rel32 field at term_pc={term_pc}, off={off} straddles a fetch window",
                 );
             }
         }

--- a/runtime/sys/linux/fault.rs
+++ b/runtime/sys/linux/fault.rs
@@ -13,16 +13,18 @@
 //! It owns the host `SIGSEGV`/`SIGBUS` disposition. The guest's own handlers for
 //! those are recorded in the disposition table but never installed on the host
 //! slot ([`super::signal`]), so this handler always runs first and can classify
-//! the fault. Besides SMC writes it recognizes one other recoverable fault, in
-//! the style of a kernel exception table: a fault whose rip lies inside the
-//! `chimera_fetch_copy` primitive — the translator probing an untrusted guest
-//! address for its decode window — resumes at the primitive's fixup label,
-//! which reports the readable prefix. A fault that is neither — a genuine guest
-//! fault, or one taken in Chimera's own code — prints a crash report
-//! ([`report_fault`]) in the style of a kernel OOPS (cause, faulting addresses,
-//! the full guest register file, the faulting instruction's bytes, and a slice
-//! of the stack) and is then left to terminate the process with the faithful
-//! signal; precise delivery into a guest fault handler is not modeled.
+//! the fault. Besides SMC writes it recognizes two recoverable faults in the
+//! style of a kernel exception table: a fault whose rip lies inside the
+//! translator's `chimera_fetch_copy` primitive resumes at its fixup label,
+//! which reports the readable decode-window prefix, and a fault inside
+//! [`crate::arch::x86::trampoline::guarded_copy`] resumes at that routine's
+//! failure tail so `copy_from_guest` reports a failed read. A fault that is
+//! neither — a genuine guest fault, or one taken in Chimera's own code — prints
+//! a crash report ([`report_fault`]) in the style of a kernel OOPS (cause,
+//! faulting addresses, the full guest register file, the faulting instruction's
+//! bytes, and a slice of the stack) and is then left to terminate the process
+//! with the faithful signal; precise delivery into a guest fault handler is not
+//! modeled.
 //!
 //! The handler is async-signal-safe: it touches only atomics, a `Mutex` and
 //! `HashMap` whose operations never allocate, and `mprotect`. It must not call
@@ -38,7 +40,10 @@ use std::{
 };
 
 use crate::{
-    arch::x86::{trampoline::fetch_copy_span, translate::code_cache_contains},
+    arch::x86::{
+        trampoline::{fetch_copy_span, guarded_copy_fixup, in_guarded_copy},
+        translate::code_cache_contains,
+    },
     process::Process,
 };
 
@@ -105,6 +110,15 @@ extern "C" fn chimera_fault(
     let (fetch_start, fetch_fixup) = fetch_copy_span();
     if (fetch_start..fetch_fixup).contains(&rip) {
         set_fault_rip(ucontext, fetch_fixup);
+        return;
+    }
+
+    // A fault inside the guarded copy routine is a failed read of untrusted
+    // guest memory (`copy_from_guest`): resume the interrupted thread at the
+    // routine's fixup label, which reports the failure to its caller — the
+    // kernel's `copy_from_user` exception-table pattern.
+    if in_guarded_copy(rip) {
+        set_fault_rip(ucontext, guarded_copy_fixup());
         return;
     }
 

--- a/runtime/sys/mmap.rs
+++ b/runtime/sys/mmap.rs
@@ -10,7 +10,10 @@ use std::{
     },
 };
 
-use crate::{Error, arch::x86::cache::BlockCache};
+use crate::{
+    Error,
+    arch::x86::{cache::BlockCache, trampoline::guarded_copy},
+};
 
 /// Guest page size (x86-64); SMC arming and invalidation work per page.
 const PAGE: usize = 4096;
@@ -300,11 +303,15 @@ pub fn reset_cached_pid() {
 
 /// Copy `buf.len()` bytes out of guest memory at `addr` without trusting the
 /// pointer. Chimera and the guest share one address space, so the copy is a
-/// self-targeted `process_vm_readv`: the kernel walks the page tables and an
-/// unmapped or partially mapped range fails the copy — exactly where a raw
-/// dereference would fault the runtime. Returns false on any failed or short
-/// copy, so a caller reports `EFAULT` (or forwards for the kernel to) the way
-/// a native `copy_from_user` failure would.
+/// plain load loop ([`guarded_copy`]) whose faults the `SIGSEGV`/`SIGBUS`
+/// handler recovers — the kernel's `copy_from_user` exception-table pattern.
+/// An unmapped or partially mapped range fails the copy exactly where a bare
+/// dereference would fault the runtime, and the common, fully mapped case
+/// costs a `memcpy` instead of a system call: the translator takes this path
+/// for every basic block it decodes, hundreds of thousands of times in a JIT
+/// warm-up. Returns false on any failed copy, so a caller reports `EFAULT`
+/// (or forwards for the kernel to) the way a native `copy_from_user` failure
+/// would.
 pub fn copy_from_guest(addr: u64, buf: &mut [u8]) -> bool {
     if buf.is_empty() {
         return true;
@@ -312,16 +319,7 @@ pub fn copy_from_guest(addr: u64, buf: &mut [u8]) -> bool {
     if addr == 0 {
         return false;
     }
-    let local = libc::iovec {
-        iov_base: buf.as_mut_ptr().cast(),
-        iov_len: buf.len(),
-    };
-    let remote = libc::iovec {
-        iov_base: addr as *mut libc::c_void,
-        iov_len: buf.len(),
-    };
-    let copied = unsafe { libc::process_vm_readv(own_pid(), &local, 1, &remote, 1, 0) };
-    copied == buf.len() as isize
+    unsafe { guarded_copy(buf.as_mut_ptr(), addr as *const u8, buf.len()) != 0 }
 }
 
 /// Copy `buf` into guest memory at `addr` without trusting the pointer — the

--- a/testing/conformance/abi/far-rip-relative.c
+++ b/testing/conformance/abi/far-rip-relative.c
@@ -1,0 +1,70 @@
+// RUN: %cc -O2 %s -static -nostdlib -Wl,-Ttext-segment=0x35f50000000 -o %t && %runner %t; test $? = 42
+//
+// Guest code can sit tens of terabytes away from the translated-code cache --
+// a JIT region placed at a randomized high address, or (as here) an image
+// linked at one. A RIP-relative memory operand in such code cannot keep its
+// effective address once the instruction moves into the cache: the
+// displacement no longer fits in a rel32, and a translator that leans on the
+// encoder's fixup fails the whole block. The translator must re-express the
+// access through an absolute address instead. This links the text segment at
+// 0x35f50000000 so every global access is such an operand, and exercises the
+// three shapes that matter: plain loads and stores, an indirect call through a
+// RIP-relative memory operand (the `call *fptr(%rip)` below), and a rewritten
+// load sitting between a compare and the conditional branch that reads its
+// flags, which a rewrite that clobbers the arithmetic flags would break.
+//
+// Freestanding (`-nostdlib`, own `_start`, raw `exit` syscall) because the crt
+// startup objects use 32-bit absolute relocations that cannot express a text
+// segment above 4 GiB.
+
+static volatile long counter = 5;
+
+static long flags_survive_rewrite(long a) {
+    long r, x;
+    __asm__ volatile("cmpq $7, %[a]\n\t"
+                     "movq counter(%%rip), %[x]\n\t"
+                     "jne 1f\n\t"
+                     "movq $1, %[r]\n\t"
+                     "jmp 2f\n\t"
+                     "1:\n\t"
+                     "movq $0, %[r]\n\t"
+                     "2:"
+                     : [r] "=r"(r), [x] "=r"(x)
+                     : [a] "r"(a)
+                     : "cc", "memory");
+    return r;
+}
+
+static long add_counter(long n) {
+    counter += n; /* RIP-relative load and store */
+    return counter;
+}
+
+static long (*volatile fptr)(long) = add_counter;
+
+static long call_through_rip_slot(long n) {
+    long r;
+    __asm__ volatile("movq %[n], %%rdi\n\t"
+                     "callq *fptr(%%rip)\n\t"
+                     "movq %%rax, %[r]"
+                     : [r] "=r"(r)
+                     : [n] "r"(n)
+                     : "rax", "rdi", "rsi", "rdx", "rcx", "r8", "r9", "r10",
+                       "r11", "cc", "memory");
+    return r;
+}
+
+static void exit_with(long code) {
+    __asm__ volatile("syscall" ::"a"(60L), "D"(code) : "rcx", "r11", "memory");
+    __builtin_unreachable();
+}
+
+void _start(void) {
+    if (add_counter(30) != 35)
+        exit_with(1);
+    if (call_through_rip_slot(7) != 42)
+        exit_with(2);
+    if (!flags_survive_rewrite(7) || flags_survive_rewrite(8))
+        exit_with(3);
+    exit_with(42);
+}

--- a/testing/conformance/signals/async-direct-recursion.c
+++ b/testing/conformance/signals/async-direct-recursion.c
@@ -15,10 +15,14 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-// A handful of slow `idiv`s per call: enough to keep the recursion well short of
-// overflow for tens of ms (so the signal lands first) while keeping the
-// straight-line block far under the translator's basic-block size limit.
-#define V8(x) x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr; x /= dvr;
+// A couple thousand slow `div`s per call keep stack overflow the better part of
+// a second away, so the helper's signal lands with a wide margin even on a slow,
+// jittery CI machine. Each step re-seeds the dividend: a plain `x /= dvr` chain
+// collapses x to 0 after two steps, and modern dividers early-out on small
+// dividends, which once made overflow arrive ~15 ms after the signal — close
+// enough for scheduler jitter to lose the race.
+#define STEP(x) x = x / dvr + 0x9e3779b97f4a7c15ull;
+#define V8(x) STEP(x) STEP(x) STEP(x) STEP(x) STEP(x) STEP(x) STEP(x) STEP(x)
 #define V64(x) V8(x) V8(x) V8(x) V8(x) V8(x) V8(x) V8(x) V8(x)
 
 static volatile uint64_t sink;
@@ -37,7 +41,8 @@ static void on_sig(int sig) {
 
 static void recurse(void) {
     uint64_t x = sink + 0x9e3779b97f4a7c15ull;
-    V64(x) // straight-line work: slows the call rate, no back-edge of its own
+    // Straight-line work: slows the call rate, no back-edge of its own.
+    V64(x) V64(x) V64(x) V64(x)
     sink = x;
     recurse(); // direct self-call: the only loop-closing edge (compiled at -O0,
                // so it is a real `call`, not a tail-call `jmp`)

--- a/testing/conformance/threads/smc-concurrent-invalidate.c
+++ b/testing/conformance/threads/smc-concurrent-invalidate.c
@@ -1,0 +1,94 @@
+// RUN: %cc %s -pthread -o %t && %runner %t
+//
+// Concurrent code-page writes while a sibling thread executes from the page.
+// A concurrent JIT (JavaScriptCore compiling on worker threads) routinely
+// stores into a page that holds code other threads are hot in — new functions,
+// inline-cache data — without stopping the world; the stores land next to the
+// executed bytes, never over them. A dynamic translator that invalidates its
+// translations on such a write must drop and re-link them with the executing
+// thread still running full speed out of its code cache: any non-atomic
+// rewrite of reachable cache bytes is a window where the executor decodes a
+// spliced instruction and computes garbage.
+//
+// One thread calls a function built in a JIT page in a tight loop, checking
+// its result on every call; another hammers a data byte elsewhere in the same
+// page, so every re-translation arms the page and the next store invalidates
+// it again. The function's small internal loop gives the translation linked
+// blocks and a back-edge inside the invalidated page, so each round severs and
+// relinks real edges. Any torn decode shows up as a wrong return value (or a
+// crash); the test fails loudly rather than hanging thanks to the alarm.
+//
+// The function, at offset 0 (data byte at offset 2048):
+//   sum(n): eax = 0; do { eax += n; n -= 1 } while (n > 0); ret
+// so sum(n) = n(n+1)/2 for n >= 1.
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#if defined(__x86_64__) && defined(__linux__)
+
+typedef int (*fn)(int);
+
+static unsigned char *page;
+static atomic_int writer_done;
+
+// mov eax, 0        ; b8 00 00 00 00
+// .loop:
+// add eax, edi      ; 01 f8
+// sub edi, 1        ; 83 ef 01
+// jg .loop          ; 7f f9
+// ret               ; c3
+static const unsigned char sum_code[] = {0xB8, 0x00, 0x00, 0x00, 0x00, 0x01,
+                                         0xF8, 0x83, 0xEF, 0x01, 0x7F, 0xF9,
+                                         0xC3};
+
+static void *writer(void *arg) {
+    (void) arg;
+    for (int i = 0; i < 20000; i++) {
+        page[2048] = (unsigned char) i; // same page as the code, not the code
+        if ((i & 63) == 0)
+            sched_yield();
+    }
+    atomic_store(&writer_done, 1);
+    return 0;
+}
+
+// Several executors, so re-entry into a freshly invalidated or relinked block
+// is always in flight on some core when the writer's store tears translations
+// down.
+static void *executor(void *arg) {
+    (void) arg;
+    fn sum = (fn) page;
+    while (!atomic_load(&writer_done))
+        for (int n = 1; n <= 8; n++)
+            if (sum(n) != n * (n + 1) / 2)
+                _exit(2); // a torn decode computed garbage
+    return 0;
+}
+
+int main(void) {
+    page = mmap(0, 4096, PROT_READ | PROT_WRITE | PROT_EXEC,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (page == MAP_FAILED) return 1;
+    memcpy(page, sum_code, sizeof sum_code);
+    __builtin___clear_cache((char *) page, (char *) page + 4096);
+
+    alarm(30); // a wedged executor fails the test instead of hanging it
+
+    pthread_t w, x[4];
+    if (pthread_create(&w, 0, writer, 0)) return 1;
+    for (int i = 0; i < 4; i++)
+        if (pthread_create(&x[i], 0, executor, 0)) return 1;
+
+    for (int i = 0; i < 4; i++)
+        if (pthread_join(x[i], 0)) return 1;
+    if (pthread_join(w, 0)) return 1;
+    return 0;
+}
+
+#else
+#error "unsupported host for smc-concurrent-invalidate test"
+#endif


### PR DESCRIPTION
With these patches, `opencode` now runs under Chimera.