### PR TITLE
runtime: never splice reachable code when linking or invalidating blocks

### DIFF
--- a/runtime/arch/x86/cache.rs
+++ b/runtime/arch/x86/cache.rs
@@ -8,6 +8,17 @@
 //! branch graph. Linking keeps a chain of blocks running back-to-back inside a
 //! single `dispatch()` call instead of round-tripping through the run loop at
 //! every basic-block boundary.
+//!
+//! Sibling threads execute out of the cache the whole time this bookkeeping
+//! runs, so every mutation of reachable code is a single aligned atomic store
+//! into a `rel32` field ([`patch_site`]) — a branch is re-aimed, but no
+//! instruction bytes are ever spliced. Invalidation severs a dropped block's
+//! incoming edges the same way, re-aiming each one back at its own cold exit
+//! stub; the dropped block's body is left intact (cache memory is never reused
+//! short of [`BlockCache::reset`]), so a thread already in flight through a
+//! stale edge executes one intact pre-invalidation block and re-resolves at
+//! its next boundary — the same staleness a native core sees when it executes
+//! prefetched bytes an instant before a cross-modifying write lands.
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -23,21 +34,21 @@ use super::translate::{CodeCache, OutEdge, Translation, translate};
 /// touches it.
 const PAGE: u64 = 4096;
 
-/// One translated block's bookkeeping: where its host code begins and the
-/// address of its deopt stub (used to neutralize the block on invalidation).
-#[derive(Clone, Copy)]
-struct Block {
-    host: u64,
-    deopt: u64,
+/// One direct-branch link site: the address of a patchable `rel32` field and
+/// the address of the cold exit stub the field targets while its edge is
+/// unlinked.
+struct LinkSite {
+    site: usize,
+    stub: u64,
 }
 
-/// The translated-block cache: the host code buffer, the guest-PC → block map,
-/// the page → blocks index that drives SMC invalidation, and the pending
-/// direct-branch links awaiting their successors.
+/// The translated-block cache: the host code buffer, the guest-PC → host-PC
+/// map, the page → blocks index that drives SMC invalidation, and the link
+/// registry that records every direct branch by successor.
 pub struct BlockCache {
     cache: CodeCache,
-    /// Guest block PC -> the block translated there.
-    map: HashMap<u64, Block>,
+    /// Guest block PC -> its host entry.
+    map: HashMap<u64, u64>,
     /// Guest page base -> start PCs of the blocks whose code touches that page,
     /// so a write to the page can find and drop them. A block spanning two pages
     /// is listed under both; stale entries (a block already dropped) are skipped
@@ -45,11 +56,17 @@ pub struct BlockCache {
     /// `BTreeMap` so [`invalidate_range`] can drop a span of pages without
     /// walking the whole index — a guest `munmap`/`mprotect` may cover gigabytes.
     page_blocks: BTreeMap<u64, Vec<u64>>,
-    /// Direct branches awaiting their successor: guest target PC -> addresses
-    /// of the `rel32` displacement fields to rewrite once that block exists.
-    /// An edge whose target is already translated is patched on the spot and
-    /// never lands here. Drained in [`BlockCache::resolve`].
-    pending: HashMap<u64, Vec<usize>>,
+    /// Successor guest PC -> every direct-branch site that targets it, live for
+    /// the lifetime of the cache. A site is aimed at the successor's host entry
+    /// exactly while that guest PC is in `map`, and at its own cold exit stub
+    /// otherwise: translation patches the list toward the new entry, and
+    /// invalidation patches it back ([`invalidate_page`] runs inside the
+    /// synchronous fault handler, so severing edges must not allocate — it only
+    /// walks this list and stores). Sites inside blocks that have themselves
+    /// been dropped linger here; re-aiming them writes into cache bytes nothing
+    /// jumps to any more, which is harmless, and they are shed only at
+    /// [`reset`].
+    links: HashMap<u64, Vec<LinkSite>>,
 }
 
 impl BlockCache {
@@ -58,7 +75,7 @@ impl BlockCache {
             cache: CodeCache::new(cache_size)?,
             map: HashMap::new(),
             page_blocks: BTreeMap::new(),
-            pending: HashMap::new(),
+            links: HashMap::new(),
         })
     }
 
@@ -68,10 +85,11 @@ impl BlockCache {
     /// returns `None` for the span.
     ///
     /// On a translation, the new block is linked into the cache's branch graph:
-    /// any direct branches that were waiting for this guest PC are patched to
-    /// jump straight here, and the new block's own outgoing direct branches are
-    /// either patched to their (already-translated) successors or recorded as
-    /// pending. After warm-up, chains of linked blocks execute back-to-back
+    /// every direct branch registered for this guest PC — waiting since its own
+    /// translation, or severed by an earlier invalidation — is patched to jump
+    /// straight here, and the new block's own outgoing direct branches are
+    /// registered under their successors and patched to any that are already
+    /// translated. After warm-up, chains of linked blocks execute back-to-back
     /// without returning to the dispatcher.
     pub fn resolve(
         &mut self,
@@ -80,17 +98,16 @@ impl BlockCache {
         syscall_exit: u64,
         trap_exit: u64,
     ) -> Result<(u64, Option<(u64, u64)>), Error> {
-        if let Some(&block) = self.map.get(&guest_pc) {
+        if let Some(&host) = self.map.get(&guest_pc) {
             // Refresh the in-cache lookup entry: reaching here means an indirect
             // branch missed it (a direct-mapped collision evicted it), so
             // reinstate it to return the hot target to the fast path.
-            self.cache.ib_insert(guest_pc, block.host);
-            return Ok((block.host, None));
+            self.cache.ib_insert(guest_pc, host);
+            return Ok((host, None));
         }
         let Translation {
             host_pc,
             guest_end,
-            deopt_pc,
             edges,
         } = translate(
             &mut self.cache,
@@ -99,13 +116,7 @@ impl BlockCache {
             syscall_exit,
             trap_exit,
         )?;
-        self.map.insert(
-            guest_pc,
-            Block {
-                host: host_pc,
-                deopt: deopt_pc,
-            },
-        );
+        self.map.insert(guest_pc, host_pc);
         // Index the block under every guest page it touches.
         let mut page = guest_pc & !(PAGE - 1);
         let last = guest_end.saturating_sub(1) & !(PAGE - 1);
@@ -119,36 +130,46 @@ impl BlockCache {
         // Mirror the mapping into the in-cache lookup table so indirect
         // branches to this block resolve without leaving the cache.
         self.cache.ib_insert(guest_pc, host_pc);
-        if let Some(sites) = self.pending.remove(&guest_pc) {
-            for site in sites {
-                patch_site(site, host_pc);
+        if let Some(sites) = self.links.get(&guest_pc) {
+            for s in sites {
+                patch_site(s.site, host_pc);
             }
         }
-        for OutEdge { target_guest, site } in edges {
-            match self.map.get(&target_guest) {
-                Some(&target) => patch_site(site, target.host),
-                None => self.pending.entry(target_guest).or_default().push(site),
+        for OutEdge {
+            target_guest,
+            site,
+            stub,
+        } in edges
+        {
+            if let Some(&target) = self.map.get(&target_guest) {
+                patch_site(site, target);
             }
+            self.links
+                .entry(target_guest)
+                .or_default()
+                .push(LinkSite { site, stub });
         }
         Ok((host_pc, Some((guest_pc, guest_end))))
     }
 
     /// Drop every block whose code touches guest `page`, for self-modifying
     /// code: each is removed from the map, evicted from the indirect-branch
-    /// table, and its host entry redirected to its deopt stub so any surviving
-    /// direct link into it re-translates. Returns whether anything was dropped.
+    /// table, and severed from the branch graph — every direct branch linked to
+    /// it is re-aimed at its own cold exit stub, so the next traversal of the
+    /// edge falls back to the dispatcher and re-translates from current guest
+    /// memory. Returns whether anything was dropped.
     ///
     /// Allocation-free: it runs inside the synchronous fault handler, so it must
     /// not call the allocator. The page's block list is cleared in place
-    /// (retaining its buffer) rather than removed, and `HashMap::remove` neither
-    /// shrinks nor frees.
+    /// (retaining its buffer) rather than removed, `HashMap::remove` neither
+    /// shrinks nor frees, and unlinking only walks `links` and stores.
     pub fn invalidate_page(&mut self, page: u64) -> bool {
         let mut dropped = false;
         if let Some(starts) = self.page_blocks.get_mut(&page) {
             for &guest_pc in starts.iter() {
-                if let Some(block) = self.map.remove(&guest_pc) {
+                if self.map.remove(&guest_pc).is_some() {
                     self.cache.ib_remove(guest_pc);
-                    self.cache.neutralize(block.host, block.deopt);
+                    unlink(&self.links, guest_pc);
                     dropped = true;
                 }
             }
@@ -165,9 +186,9 @@ impl BlockCache {
     pub fn invalidate_range(&mut self, lo_page: u64, hi_page: u64) {
         for (_, starts) in self.page_blocks.range_mut(lo_page..=hi_page) {
             for &guest_pc in starts.iter() {
-                if let Some(block) = self.map.remove(&guest_pc) {
+                if self.map.remove(&guest_pc).is_some() {
                     self.cache.ib_remove(guest_pc);
-                    self.cache.neutralize(block.host, block.deopt);
+                    unlink(&self.links, guest_pc);
                 }
             }
             starts.clear();
@@ -193,13 +214,24 @@ impl BlockCache {
     }
 
     /// Flush every translated block and its link bookkeeping. The backing code
-    /// buffer is rewound; the guest-PC map, page index, and pending links are
+    /// buffer is rewound; the guest-PC map, page index, and link registry are
     /// cleared.
     pub fn reset(&mut self) {
         self.cache.reset();
         self.map.clear();
         self.page_blocks.clear();
-        self.pending.clear();
+        self.links.clear();
+    }
+}
+
+/// Sever every direct branch targeting `guest_pc` by re-aiming its `rel32`
+/// back at its own cold exit stub — the reverse of the linking in
+/// [`BlockCache::resolve`], and the same single atomic store.
+fn unlink(links: &HashMap<u64, Vec<LinkSite>>, guest_pc: u64) {
+    if let Some(sites) = links.get(&guest_pc) {
+        for s in sites {
+            patch_site(s.site, s.stub);
+        }
     }
 }
 
@@ -208,11 +240,12 @@ impl BlockCache {
 /// the end of its own four bytes. The cache stays well under 2 GiB, so the
 /// signed distance always fits in an `i32`.
 ///
-/// The translator aligns every patchable `rel32` field to a 4-byte boundary
-/// (see `build_linked_terminator`), so this is a single aligned atomic store:
-/// a sibling thread executing the branch reads either the old target (its cold
-/// exit stub, which round-trips through the dispatcher) or the new one, never a
-/// torn displacement spliced from both. x86 keeps instruction and data caches
+/// The translator places every patchable `rel32` field on a 4-byte boundary
+/// that keeps the whole branch instruction inside one aligned 16-byte fetch
+/// window (see `pad_rel32_alignment`), so this single aligned atomic store is
+/// indivisible for a sibling thread's instruction fetch as well: the sibling
+/// executes the branch toward the old target or the new one, never a torn
+/// displacement spliced from both. x86 keeps instruction and data caches
 /// coherent, so the executing core picks up the new target on its next fetch.
 fn patch_site(site: usize, host_pc: u64) {
     let disp = host_pc as i64 - (site as i64 + 4);
@@ -221,8 +254,8 @@ fn patch_site(site: usize, host_pc: u64) {
         "link displacement {disp} out of rel32 range"
     );
     debug_assert!(
-        site.is_multiple_of(4),
-        "link site {site:#x} is not 4-byte aligned"
+        site.is_multiple_of(4) && !site.is_multiple_of(16),
+        "link site {site:#x} straddles a fetch window"
     );
     let slot = unsafe { &*(site as *const AtomicI32) };
     slot.store(disp as i32, Ordering::Release);

--- a/runtime/arch/x86/translate.rs
+++ b/runtime/arch/x86/translate.rs
@@ -268,33 +268,6 @@ impl CodeCache {
         }
     }
 
-    /// Redirect a block's host entry to its deopt stub by overwriting the first
-    /// 5 bytes at `host_pc` with `jmp rel32 -> deopt_pc`. Called when the guest
-    /// modifies the page the block was translated from: the block is dropped
-    /// from the map, and any direct branch still linked to it now lands on the
-    /// stub, which exits to the dispatcher and re-translates from current guest
-    /// memory. Relies on JIT discipline — the guest stops every thread before
-    /// rewriting code it might be running — so no sibling executes this block
-    /// while it is patched. The `jmp` opcode is published last, so a reader that
-    /// somehow raced would see the original instruction until the redirect is
-    /// fully formed rather than a spliced one.
-    pub fn neutralize(&self, host_pc: u64, deopt_pc: u64) {
-        let rel = deopt_pc as i64 - (host_pc as i64 + 5);
-        debug_assert!(
-            i32::try_from(rel).is_ok(),
-            "deopt displacement {rel} out of rel32 range"
-        );
-        let rel = rel as i32 as u32;
-        unsafe {
-            let p = host_pc as *mut u8;
-            ptr::write_volatile(p.add(1), rel as u8);
-            ptr::write_volatile(p.add(2), (rel >> 8) as u8);
-            ptr::write_volatile(p.add(3), (rel >> 16) as u8);
-            ptr::write_volatile(p.add(4), (rel >> 24) as u8);
-            ptr::write_volatile(p, 0xE9);
-        }
-    }
-
     /// Drop `guest_pc` from the inline indirect-branch table if it currently
     /// holds the slot, so a later indirect branch to it misses and re-resolves
     /// through the dispatcher (where the block has been dropped and re-translates
@@ -566,26 +539,27 @@ fn gs_qword(disp: i64) -> MemoryOperand {
 }
 
 /// A patchable outgoing edge of a translated block: the guest PC of a
-/// statically known successor, and the address of the `rel32` displacement
-/// field of the direct branch that currently targets the block's cold exit
-/// stub. Once the successor is translated, the dispatcher rewrites the
-/// displacement so the branch jumps straight into the successor's host code,
-/// keeping the guest register file live across the edge instead of
-/// round-tripping through the dispatcher. See [`super::super::sys::mmap`].
+/// statically known successor, the address of the `rel32` displacement field
+/// of the direct branch that currently targets the block's cold exit stub, and
+/// the address of that stub. Once the successor is translated, the dispatcher
+/// rewrites the displacement so the branch jumps straight into the successor's
+/// host code, keeping the guest register file live across the edge instead of
+/// round-tripping through the dispatcher; when the successor is invalidated,
+/// the dispatcher rewrites it back to `stub`, severing the edge with the same
+/// single atomic store. See [`super::super::sys::mmap`].
 pub struct OutEdge {
     pub target_guest: u64,
     pub site: usize,
+    pub stub: u64,
 }
 
 /// The result of translating one basic block: where its host code begins, the
 /// guest PC one past its last decoded byte (so the cache knows which guest pages
-/// the block covers, for self-modifying-code invalidation), the address of its
-/// deopt stub (see [`CodeCache::neutralize`]), and its statically known outgoing
-/// edges for the dispatcher to link.
+/// the block covers, for self-modifying-code invalidation), and its statically
+/// known outgoing edges for the dispatcher to link.
 pub struct Translation {
     pub host_pc: u64,
     pub guest_end: u64,
-    pub deopt_pc: u64,
     pub edges: Vec<OutEdge>,
 }
 
@@ -746,9 +720,10 @@ pub fn translate(
         cache.emit(&bytes)?;
         rel_edges
             .into_iter()
-            .map(|(off, target_guest)| OutEdge {
+            .map(|(off, stub_off, target_guest)| OutEdge {
                 target_guest,
                 site: term_pc + off,
+                stub: (term_pc + stub_off) as u64,
             })
             .collect()
     } else {
@@ -757,20 +732,9 @@ pub fn translate(
         Vec::new()
     };
 
-    // A per-block deopt stub: it saves rax, publishes this block's own guest PC
-    // into the rip slot, and exits to the dispatcher. SMC invalidation overwrites
-    // the block's host entry with a 5-byte jump to this stub, so any surviving
-    // direct link into the dropped block falls back to the dispatcher and
-    // re-translates from current guest memory (see [`CodeCache::neutralize`]).
-    let deopt_pc = cache.next_pc();
-    let mut stub = Vec::new();
-    emit_stub(&mut stub, guest_pc, exit_tramp);
-    cache.emit(&stub)?;
-
     Ok(Translation {
         host_pc,
         guest_end,
-        deopt_pc,
         edges,
     })
 }
@@ -1066,10 +1030,11 @@ fn emit_exit_poll(out: &mut Vec<u8>) -> usize {
 
 /// Build the raw machine code for a linkable terminator: a fast-path direct
 /// branch followed by one cold exit stub per successor. Returns the encoded
-/// bytes and, for each edge, the byte offset of its fast-path `rel32`
-/// displacement paired with the successor's guest PC. The displacements are
-/// initialized to target the stubs; the dispatcher rewrites them to the
-/// successor blocks as those are translated.
+/// bytes and, for each edge, the byte offsets of its fast-path `rel32`
+/// displacement and of its cold exit stub, paired with the successor's guest
+/// PC. The displacements are initialized to target the stubs; the dispatcher
+/// rewrites them to the successor blocks as those are translated, and back to
+/// the stubs when a successor is invalidated.
 ///
 /// A back-edge ([`is_back_edge`]) is preceded by a safepoint poll
 /// ([`emit_exit_poll`]) that diverts to the edge's own cold-exit stub when an
@@ -1087,7 +1052,7 @@ fn build_linked_terminator(
     exit_tramp: u64,
     block_start: u64,
     term_pc: usize,
-) -> (Vec<u8>, Vec<(usize, u64)>) {
+) -> (Vec<u8>, Vec<(usize, usize, u64)>) {
     let mut out = Vec::new();
     let mut edges = Vec::new();
     match *link {
@@ -1106,7 +1071,7 @@ fn build_linked_terminator(
             if let Some(poll_rel) = poll {
                 write_rel32(&mut out, poll_rel, stub);
             }
-            edges.push((rel, target));
+            edges.push((rel, stub, target));
         }
         LinkTerm::Cond {
             opcode,
@@ -1140,8 +1105,8 @@ fn build_linked_terminator(
                 write_rel32(&mut out, jmp_rel, fall_stub);
                 write_rel32(&mut out, taken_jmp_rel, taken_stub);
                 write_rel32(&mut out, poll_rel, taken_stub);
-                edges.push((taken_jmp_rel, taken));
-                edges.push((jmp_rel, fallthrough));
+                edges.push((taken_jmp_rel, taken_stub, taken));
+                edges.push((jmp_rel, fall_stub, fallthrough));
             } else {
                 // jcc rel32 -> taken stub ; jmp rel32 -> fall-through stub.
                 // The native jcc reads the block's live guest flags directly. Each
@@ -1158,8 +1123,8 @@ fn build_linked_terminator(
                 emit_stub(&mut out, fallthrough, exit_tramp);
                 write_rel32(&mut out, jcc_rel, taken_stub);
                 write_rel32(&mut out, jmp_rel, fall_stub);
-                edges.push((jcc_rel, taken));
-                edges.push((jmp_rel, fallthrough));
+                edges.push((jcc_rel, taken_stub, taken));
+                edges.push((jmp_rel, fall_stub, fallthrough));
             }
         }
         LinkTerm::ShortCond {
@@ -1206,8 +1171,8 @@ fn build_linked_terminator(
             if let Some(poll_rel) = poll {
                 write_rel32(&mut out, poll_rel, taken_stub);
             }
-            edges.push((taken_rel, taken));
-            edges.push((fall_rel, fallthrough));
+            edges.push((taken_rel, taken_stub, taken));
+            edges.push((fall_rel, fall_stub, fallthrough));
         }
         LinkTerm::DirectCall { target, ret } => {
             // Push the 64-bit return address with a single 8-byte store so the
@@ -1242,7 +1207,7 @@ fn build_linked_terminator(
             if let Some(poll_rel) = poll {
                 write_rel32(&mut out, poll_rel, stub);
             }
-            edges.push((rel, target));
+            edges.push((rel, stub, target));
         }
     }
     (out, edges)
@@ -1432,12 +1397,25 @@ fn take_rel32(out: &mut Vec<u8>) -> usize {
 }
 
 /// Pad `out` with single-byte NOPs until the `rel32` field that will follow
-/// `opcode_len` opcode bytes lands on a 4-byte boundary in the cache, given the
-/// terminator will be emitted at `term_pc`. A naturally aligned `rel32` can be
-/// back-patched with a single atomic 32-bit store, so a sibling thread executing
-/// the branch sees the old displacement or the new one but never a torn mix.
+/// `opcode_len` opcode bytes lands on a 4-byte boundary in the cache — but not
+/// a 16-byte one — given the terminator will be emitted at `term_pc`.
+///
+/// The 4-byte alignment lets the field be back-patched with a single atomic
+/// 32-bit store; that alone, though, only makes the *store* indivisible. A
+/// sibling core's instruction fetch is not an atomic 4-byte load: it decodes
+/// from aligned 16-byte fetch windows, and a branch whose opcode sits at the
+/// end of one window with its displacement in the next can pair a stale opcode
+/// fetch with a fresh displacement fetch (or half of each) — a spliced branch
+/// that lands mid-instruction. Keeping the field off 16-byte boundaries puts
+/// the whole instruction — opcode (1 or 2 bytes, so field offsets 4, 8, and 12
+/// all work) plus displacement — inside one fetch window, so any single fetch
+/// observes the branch either entirely old or entirely new.
 fn pad_rel32_alignment(out: &mut Vec<u8>, term_pc: usize, opcode_len: usize) {
-    while !(term_pc + out.len() + opcode_len).is_multiple_of(4) {
+    loop {
+        let rel = term_pc + out.len() + opcode_len;
+        if rel.is_multiple_of(4) && !rel.is_multiple_of(16) {
+            break;
+        }
         out.push(0x90); // nop
     }
 }
@@ -1832,26 +1810,38 @@ mod tests {
     use super::*;
 
     /// Every patchable `rel32` field of a linked terminator must land on a
-    /// 4-byte boundary, whatever address the terminator is emitted at, so the
-    /// dispatcher can back-patch it with one aligned atomic store. Check all
-    /// eight residues of `term_pc` mod 4 so the padding is exercised for every
+    /// 4-byte boundary — but off 16-byte ones, so the whole branch instruction
+    /// sits inside one aligned 16-byte fetch window — whatever address the
+    /// terminator is emitted at, so the dispatcher can back-patch it with one
+    /// store that is atomic for a sibling's instruction fetch too. Check every
+    /// residue of `term_pc` mod 16 so the padding is exercised for every
     /// starting alignment.
     fn assert_edges_aligned(link: &LinkTerm) {
-        for term_pc in 0..8usize {
+        for term_pc in 0..16usize {
             // block_start 0: every target here is a forward edge (no safepoint
             // poll), exercising the bare linked-terminator alignment.
             let (bytes, edges) = build_linked_terminator(link, 0xdead_beef, 0, term_pc);
             assert!(!edges.is_empty(), "a linked terminator must expose an edge");
-            for (off, _target) in edges {
+            for (off, stub, _target) in edges {
                 assert!(
                     off + 4 <= bytes.len(),
                     "rel32 field at off={off} runs past the {} terminator bytes",
+                    bytes.len(),
+                );
+                assert!(
+                    stub <= bytes.len(),
+                    "stub at off={stub} lies past the {} terminator bytes",
                     bytes.len(),
                 );
                 assert_eq!(
                     (term_pc + off) % 4,
                     0,
                     "rel32 field at term_pc={term_pc}, off={off} is not 4-byte aligned",
+                );
+                assert_ne!(
+                    (term_pc + off) % 16,
+                    0,
+                    "rel32 field at term_pc={term_pc}, off={off} straddles a fetch window",
                 );
             }
         }

--- a/testing/conformance/threads/smc-concurrent-invalidate.c
+++ b/testing/conformance/threads/smc-concurrent-invalidate.c
@@ -1,0 +1,94 @@
+// RUN: %cc %s -pthread -o %t && %runner %t
+//
+// Concurrent code-page writes while a sibling thread executes from the page.
+// A concurrent JIT (JavaScriptCore compiling on worker threads) routinely
+// stores into a page that holds code other threads are hot in — new functions,
+// inline-cache data — without stopping the world; the stores land next to the
+// executed bytes, never over them. A dynamic translator that invalidates its
+// translations on such a write must drop and re-link them with the executing
+// thread still running full speed out of its code cache: any non-atomic
+// rewrite of reachable cache bytes is a window where the executor decodes a
+// spliced instruction and computes garbage.
+//
+// One thread calls a function built in a JIT page in a tight loop, checking
+// its result on every call; another hammers a data byte elsewhere in the same
+// page, so every re-translation arms the page and the next store invalidates
+// it again. The function's small internal loop gives the translation linked
+// blocks and a back-edge inside the invalidated page, so each round severs and
+// relinks real edges. Any torn decode shows up as a wrong return value (or a
+// crash); the test fails loudly rather than hanging thanks to the alarm.
+//
+// The function, at offset 0 (data byte at offset 2048):
+//   sum(n): eax = 0; do { eax += n; n -= 1 } while (n > 0); ret
+// so sum(n) = n(n+1)/2 for n >= 1.
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#if defined(__x86_64__) && defined(__linux__)
+
+typedef int (*fn)(int);
+
+static unsigned char *page;
+static atomic_int writer_done;
+
+// mov eax, 0        ; b8 00 00 00 00
+// .loop:
+// add eax, edi      ; 01 f8
+// sub edi, 1        ; 83 ef 01
+// jg .loop          ; 7f f9
+// ret               ; c3
+static const unsigned char sum_code[] = {0xB8, 0x00, 0x00, 0x00, 0x00, 0x01,
+                                         0xF8, 0x83, 0xEF, 0x01, 0x7F, 0xF9,
+                                         0xC3};
+
+static void *writer(void *arg) {
+    (void) arg;
+    for (int i = 0; i < 20000; i++) {
+        page[2048] = (unsigned char) i; // same page as the code, not the code
+        if ((i & 63) == 0)
+            sched_yield();
+    }
+    atomic_store(&writer_done, 1);
+    return 0;
+}
+
+// Several executors, so re-entry into a freshly invalidated or relinked block
+// is always in flight on some core when the writer's store tears translations
+// down.
+static void *executor(void *arg) {
+    (void) arg;
+    fn sum = (fn) page;
+    while (!atomic_load(&writer_done))
+        for (int n = 1; n <= 8; n++)
+            if (sum(n) != n * (n + 1) / 2)
+                _exit(2); // a torn decode computed garbage
+    return 0;
+}
+
+int main(void) {
+    page = mmap(0, 4096, PROT_READ | PROT_WRITE | PROT_EXEC,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (page == MAP_FAILED) return 1;
+    memcpy(page, sum_code, sizeof sum_code);
+    __builtin___clear_cache((char *) page, (char *) page + 4096);
+
+    alarm(30); // a wedged executor fails the test instead of hanging it
+
+    pthread_t w, x[4];
+    if (pthread_create(&w, 0, writer, 0)) return 1;
+    for (int i = 0; i < 4; i++)
+        if (pthread_create(&x[i], 0, executor, 0)) return 1;
+
+    for (int i = 0; i < 4; i++)
+        if (pthread_join(x[i], 0)) return 1;
+    if (pthread_join(w, 0)) return 1;
+    return 0;
+}
+
+#else
+#error "unsupported host for smc-concurrent-invalidate test"
+#endif


### PR DESCRIPTION
A concurrent JIT -- JavaScriptCore compiling on Bun's worker threads --
stores into pages that hold code sibling threads are executing, without
stopping the world. Each such store faults into SMC invalidation, which
overwrote every dropped block's entry with a 5-byte jmp to its deopt
stub, byte by byte, on the assumption that no thread executes the block
during the patch. Nothing upholds that assumption: a sibling entering
through a still-linked branch or an indirect-branch hit decodes a
spliced instruction and computes garbage. opencode (a Bun binary) died
nondeterministically within seconds of boot -- its crash reports show
execution sitting one byte past an instruction boundary, and guest
registers with their top halves truncated by a REX prefix lost to the
misaligned decode.

Invalidate by severing edges instead of rewriting entries: every direct
branch site is registered under its successor's guest PC (the links
table, replacing pending), and dropping a block re-aims each incoming
rel32 at that site's own cold exit stub -- the same single aligned
atomic store that linking uses, and allocation-free for the fault
handler. The dropped block's body is left intact and cache memory is
never reused short of a reset, so a thread already in flight executes
at most one pre-invalidation block and re-resolves at its next
boundary: the same staleness a native core sees when it runs prefetched
bytes as a cross-modifying write lands. The per-block deopt stub goes
away.

The aligned store alone is not enough: it is atomic for data, but a
sibling's instruction fetch decodes from aligned 16-byte windows, and a
branch whose opcode ends one window with its displacement starting the
next can pair a stale opcode fetch with a fresh displacement fetch. Pad
every patchable rel32 off 16-byte boundaries too, so the whole branch
instruction sits inside one fetch window and any single fetch observes
it entirely old or entirely new.

The conformance test drives the invalidate/relink path from a writer
thread hammering a data byte on the code page while four executors
verify a looping function translated from the same page. With the fix,
opencode survives 23 consecutive pty runs where it previously crashed
about one time in seven.
