### PR TITLE
cli: pass guest arguments through verbatim

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -45,6 +45,11 @@ fn version() -> ExitCode {
 }
 
 fn run(cmd: RunCmd) -> ExitCode {
+    let Some((program, args)) = cmd.argv.split_first() else {
+        eprintln!("chimera: no program to run");
+        return ExitCode::FAILURE;
+    };
+    let program = Path::new(program);
     // Route the guest's filesystem syscalls through a userspace VFS mounted
     // at `/`. Copy-on-write is the default: every run mounts an overlay
     // whose upper layer is a filesystem's delta, so the guest works against
@@ -107,7 +112,7 @@ fn run(cmd: RunCmd) -> ExitCode {
     // guest's own syscalls will see: an attached filesystem may have replaced
     // or deleted the program, its script, or its interpreter, and the session
     // must load the bytes the guest observes, not the lower host's.
-    let program = match resolve_program(root.as_ref(), &cmd.program, &cmd.args) {
+    let program = match resolve_program(root.as_ref(), program, args) {
         Ok(program) => program,
         Err(err) => {
             eprintln!("chimera: {err}");
@@ -150,12 +155,7 @@ fn run(cmd: RunCmd) -> ExitCode {
 
 /// The command line a filesystem's provenance records.
 fn describe(cmd: &RunCmd) -> String {
-    let mut s = cmd.program.display().to_string();
-    for arg in &cmd.args {
-        s.push(' ');
-        s.push_str(arg);
-    }
-    s
+    cmd.argv.join(" ")
 }
 
 struct Program {

--- a/cli/opts.rs
+++ b/cli/opts.rs
@@ -1,7 +1,5 @@
 //! Command-line option parsing for the `chimera` program.
 
-use std::path::PathBuf;
-
 use argh::FromArgs;
 
 /// Run a command in zero-setup sandbox.
@@ -105,13 +103,10 @@ pub struct RunCmd {
     #[argh(switch, long = "unsafe")]
     pub unsafe_: bool,
 
-    /// path to the program
-    #[argh(positional)]
-    pub program: PathBuf,
-
-    /// arguments to pass to the guest
-    #[argh(positional)]
-    pub args: Vec<String>,
+    /// the program and its arguments. Greedy: option parsing stops at the
+    /// program token, so the guest's own flags need no `--` separator.
+    #[argh(positional, greedy)]
+    pub argv: Vec<String>,
 }
 
 /// Print version information.

--- a/testing/conformance/entry/guest-flags.c
+++ b/testing/conformance/entry/guest-flags.c
@@ -1,0 +1,17 @@
+// RUN: %cc %s -o %t && %runner %t --help -n -- -f x; test $? = 42
+//
+// A guest's arguments must reach it verbatim even when they look like the
+// sandbox's own options: a flag in the first position, and a literal `--`.
+// The CLI must not consume, reorder, or choke on any of them.
+
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc != 6) return 1;
+    if (strcmp(argv[1], "--help") != 0) return 2;
+    if (strcmp(argv[2], "-n") != 0) return 3;
+    if (strcmp(argv[3], "--") != 0) return 4;
+    if (strcmp(argv[4], "-f") != 0) return 5;
+    if (strcmp(argv[5], "x") != 0) return 6;
+    return 42;
+}


### PR DESCRIPTION
chimera run /bin/echo -n swallowed the guest's flags: argh kept parsing
options after the program positional, so a guest flag either collided
with a chimera option (--help) or errored as unrecognized (-n), forcing
the user to type a -- separator.

Merge the program and argument positionals into one greedy argv vector:
argh stops option parsing at the first token the greedy field consumes,
so everything from the program onward reaches the guest untouched.
Chimera's own options still work before the program, and an explicit --
still works as before.
