### PR TITLE
testing: drop the GNU timeout from RUN lines

### DIFF
--- a/testing/conformance/abi/computed-goto.c
+++ b/testing/conformance/abi/computed-goto.c
@@ -1,4 +1,4 @@
-// RUN: %cc -O2 -fPIE %s -pie -o %t && timeout 5 %runner %t
+// RUN: %cc -O2 -fPIE %s -pie -o %t && %runner %t
 //
 // A computed-goto ("labels as values") loop. With GCC on this toolchain, the
 // `-O2 -fPIE -pie` shape emits `lea label(%rip)` for the label values and keeps

--- a/testing/conformance/exec/execve-cloexec.c
+++ b/testing/conformance/exec/execve-cloexec.c
@@ -6,7 +6,7 @@
 // hangs this read forever (caught by the RUN line's timeout) exactly as
 // `git diff` hung waiting on its exec-failure notify pipe.
 //
-// RUN: %cc %s -o %t && timeout 10 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 
 #include <errno.h>
 #include <fcntl.h>

--- a/testing/conformance/isolation/cache-poison.c
+++ b/testing/conformance/isolation/cache-poison.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t && timeout 10 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 //
 // A guest must never be able to smuggle a raw host syscall past the embedder's
 // syscall handler by writing into Chimera's translated-code cache. The cache

--- a/testing/conformance/linux/segv-terminates.c
+++ b/testing/conformance/linux/segv-terminates.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t && timeout 5 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 //
 // A genuine guest fault (a write to an unmapped address) must terminate the
 // process by SIGSEGV, faithfully. Chimera owns the host SIGSEGV slot for its

--- a/testing/conformance/linux/wild-jump-terminates.c
+++ b/testing/conformance/linux/wild-jump-terminates.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t && timeout 5 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 //
 // A wild jump to unmapped memory must terminate the process by SIGSEGV,
 // faithfully. The fault here is on the instruction FETCH, not a data access:

--- a/testing/conformance/overlay/copy-up-metadata.c
+++ b/testing/conformance/overlay/copy-up-metadata.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.d && %t prep %t.d
-// RUN: CHIMERA_FS=%t.ws timeout 20 %runner %t check %t.d
+// RUN: CHIMERA_FS=%t.ws %runner %t check %t.d
 // RUN: %t verify %t.ws %t.d
 //
 // Opening a lower file with write intent copies it up — and that must not

--- a/testing/conformance/overlay/copy-up-race.c
+++ b/testing/conformance/overlay/copy-up-race.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.d && %t prep %t.d
-// RUN: timeout 60 %runner %t race %t.d
+// RUN: %runner %t race %t.d
 //
 // Copy-up publication race: two processes that both still see only the lower
 // file each build a staging copy, and publication must be first-wins. The

--- a/testing/conformance/overlay/exec-rewritten-binary.c
+++ b/testing/conformance/overlay/exec-rewritten-binary.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.fixture && %t prep %t.fixture
-// RUN: CHIMERA_FS=%t.fixture/delta timeout 10 %runner %t check %t.fixture
+// RUN: CHIMERA_FS=%t.fixture/delta %runner %t check %t.fixture
 // RUN: %t verify %t.fixture
 //
 // Exec coherence: a guest that rewrites a binary and execve's the path must

--- a/testing/conformance/overlay/fork-coherence.c
+++ b/testing/conformance/overlay/fork-coherence.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.fixture && %t prep %t.fixture
-// RUN: CHIMERA_FS=%t.fixture/delta timeout 10 %runner %t check %t.fixture
+// RUN: CHIMERA_FS=%t.fixture/delta %runner %t check %t.fixture
 // RUN: %t verify %t.fixture
 //
 // Fork coherence — the payoff of encoding all overlay state in the

--- a/testing/conformance/overlay/fs-outlives-root.c
+++ b/testing/conformance/overlay/fs-outlives-root.c
@@ -1,8 +1,8 @@
 // RUN: %cc %s -o %t && rm -rf %t.probeA %t.probeB %t.childA %t.childB %t.ws2
-// RUN: timeout 15 %runner %t scenario %t.probeA > %t.childA
+// RUN: %runner %t scenario %t.probeA > %t.childA
 // RUN: %t await %t.childA
 // RUN: %t verify-kept "$XDG_STATE_HOME/chimera/fs" %t.probeA
-// RUN: case "%runner" in *--unsafe*) : ;; *chimera*) CHIMERA_FS=%t.ws2 timeout 15 %runner --rm %t scenario %t.probeB > %t.childB && %t await %t.childB && %t verify-rm %t.ws2 %t.probeB ;; *) : ;; esac
+// RUN: case "%runner" in *--unsafe*) : ;; *chimera*) CHIMERA_FS=%t.ws2 %runner --rm %t scenario %t.probeB > %t.childB && %t await %t.childB && %t verify-rm %t.ws2 %t.probeB ;; *) : ;; esac
 //
 // The session lifetime is the guest process tree, not the root command: a
 // forked guest that outlives the session root must keep a usable filesystem.

--- a/testing/conformance/overlay/rename-merged-validation.c
+++ b/testing/conformance/overlay/rename-merged-validation.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.d && %t prep %t.d
-// RUN: timeout 20 %runner %t check %t.d
+// RUN: %runner %t check %t.d
 //
 // Rename preconditions are merged-view questions. A directory renamed over a
 // lower regular file must fail ENOTDIR and over a non-empty lower directory

--- a/testing/conformance/overlay/scaffold-metadata.c
+++ b/testing/conformance/overlay/scaffold-metadata.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.a %t.b %t.c && %t prep %t.a %t.b %t.c
-// RUN: timeout 20 %runner %t check %t.a %t.b %t.c
+// RUN: %runner %t check %t.a %t.b %t.c
 //
 // Scaffold directories are structure, not content: creating a file beneath a
 // lower directory materializes upper parents, but those exist only so the

--- a/testing/conformance/overlay/whiteout-failed-create.c
+++ b/testing/conformance/overlay/whiteout-failed-create.c
@@ -1,5 +1,5 @@
 // RUN: %cc %s -o %t && rm -rf %t.d && %t prep %t.d
-// RUN: timeout 20 %runner %t check %t.d
+// RUN: %runner %t check %t.d
 //
 // A failed syscall must leave the merged namespace exactly as it was. The
 // deleted names here are hidden by whiteouts; a creation over one that

--- a/testing/conformance/signals/handler-shared-across-threads.c
+++ b/testing/conformance/signals/handler-shared-across-threads.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -pthread -o %t && timeout 10 %runner %t
+// RUN: %cc %s -pthread -o %t && %runner %t
 //
 // Signal dispositions are process-wide (POSIX): a handler one thread installs
 // with sigaction is in force for every thread, including a thread-directed

--- a/testing/conformance/signals/int3-trap.c
+++ b/testing/conformance/signals/int3-trap.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t && timeout 5 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 //
 // A guest `int3` software breakpoint raises SIGTRAP. The translator does not run
 // the breakpoint in the cache; it exits with a trap indication and the run loop

--- a/testing/conformance/signals/thread-directed-delivery.c
+++ b/testing/conformance/signals/thread-directed-delivery.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t -pthread && timeout 5 %runner %t
+// RUN: %cc %s -o %t -pthread && %runner %t
 //
 // A thread-directed signal (pthread_kill) must be delivered ON the thread it
 // targets, even while another thread is busy passing through delivery points.

--- a/testing/conformance/threads/clone3-clear-sighand.c
+++ b/testing/conformance/threads/clone3-clear-sighand.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t && timeout 10 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 //
 // clone3's CLONE_CLEAR_SIGHAND resets the child's signal dispositions the way
 // execve does: caught handlers revert to SIG_DFL, SIG_IGN survives, and the

--- a/testing/conformance/threads/posix-spawn-exit-with-thread.c
+++ b/testing/conformance/threads/posix-spawn-exit-with-thread.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -pthread -o %t && timeout 10 %runner %t
+// RUN: %cc %s -pthread -o %t && %runner %t
 //
 // glibc's posix_spawn is clone3(CLONE_VM | CLONE_VFORK | CLONE_CLEAR_SIGHAND).
 // Chimera emulates the spawn as a host fork, and CLONE_CLEAR_SIGHAND must not

--- a/testing/conformance/threads/posix-spawn-fd-churn.c
+++ b/testing/conformance/threads/posix-spawn-fd-churn.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -pthread -o %t && timeout 20 %runner %t
+// RUN: %cc %s -pthread -o %t && %runner %t
 //
 // posix_spawn while sibling threads churn the descriptor table. A handler
 // that virtualizes descriptors pairs its table with kernel state (reserved

--- a/testing/conformance/threads/posix-spawn-threaded.c
+++ b/testing/conformance/threads/posix-spawn-threaded.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -pthread -o %t && timeout 10 %runner %t
+// RUN: %cc %s -pthread -o %t && %runner %t
 //
 // posix_spawn from a multithreaded process. Chimera emulates the spawn's
 // CLONE_VM child as a fork of its own (multithreaded) host process, so it must

--- a/testing/conformance/threads/posix-spawnp-path-walk.c
+++ b/testing/conformance/threads/posix-spawnp-path-walk.c
@@ -1,4 +1,4 @@
-// RUN: %cc %s -o %t && timeout 10 %runner %t
+// RUN: %cc %s -o %t && %runner %t
 //
 // posix_spawnp resolves the program inside the spawned child: glibc's spawn
 // child walks $PATH issuing one execve per candidate, so early ENOENT


### PR DESCRIPTION
`timeout(1)` is coreutils. macOS does not ship it — Homebrew installs it as `gtimeout` — so every RUN line carrying it dies with `sh: timeout: command not found` and exit 127 before the test under it ever runs.

It was redundant anyway. lit already bounds each RUN line itself:

    proc = subprocess.run(["sh", "-c", full], ..., timeout=timeout)
    except subprocess.TimeoutExpired:
        failure = f"timed out after {timeout:g}s\n  cmd: {full}"

with `--timeout` / `LIT_TIMEOUT`, default 120s, reported as an ordinary failure. A hung test is caught either way; the in-line prefix only tightened the bound to 5-60s. That tighter bound is the one thing lost here, and it only costs wall-clock on a test that is already broken. A portable way to keep it would be a lit directive feeding the timeout it already has, rather than shelling out to a binary half the CI hosts lack.

Measured on macOS, where the suite is otherwise unaffected by this change:

    before   77 passed, 72 failed
    after    88 passed, 61 failed

Eleven tests move from failing to passing and none regress; no `command not found` remains.