### PR TITLE
cli: identify the default shell by its filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Then wrap any command:
 chimera run /bin/echo hello
 ```
 
-With no command, `chimera run` starts `/bin/bash`.
+With no command, `chimera run` starts `/bin/bash` with a compact prompt naming
+its filesystem id. `--unsafe` replaces the id with `unsafe`; pass
+`--no-prompt` to leave the normal Bash prompt unchanged.
 
 By default Chimera forwards every system call to the host kernel, so the
 wrapped process behaves like a native one.

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -220,7 +220,7 @@ impl Filesystem {
 }
 
 /// 8 hex characters of kernel randomness.
-fn fresh_id() -> io::Result<String> {
+pub fn fresh_id() -> io::Result<String> {
     use std::io::Read;
 
     let mut bytes = [0u8; 4];

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,5 +1,6 @@
 mod fs;
 mod opts;
+mod prompt;
 
 use std::{
     env,
@@ -45,9 +46,12 @@ fn version() -> ExitCode {
 }
 
 fn run(mut cmd: RunCmd) -> ExitCode {
-    default_program(&mut cmd.argv);
-    let (program, args) = cmd.argv.split_first().expect("default program is present");
-    let program = Path::new(program);
+    // Only a shell Chimera starts on its own gets a badged prompt; a program
+    // the user named runs exactly as typed.
+    let implicit_shell = cmd.argv.is_empty();
+    if implicit_shell {
+        cmd.argv.push("/bin/bash".into());
+    }
     // Route the guest's filesystem syscalls through a userspace VFS mounted
     // at `/`. Copy-on-write is the default: every run mounts an overlay
     // whose upper layer is a filesystem's delta, so the guest works against
@@ -106,6 +110,25 @@ fn run(mut cmd: RunCmd) -> ExitCode {
             }
         }
     };
+    // Held for the whole run: dropping the prompt removes the rc file.
+    let _prompt = if implicit_shell && !cmd.no_prompt {
+        match prompt::Prompt::new(fsys.as_ref()) {
+            Ok(prompt) => {
+                cmd.argv.push("--rcfile".into());
+                cmd.argv
+                    .push(prompt.rcfile().to_string_lossy().into_owned());
+                Some(prompt)
+            }
+            Err(err) => {
+                eprintln!("chimera: cannot configure prompt: {err}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let (program, args) = cmd.argv.split_first().expect("argv names a program");
+    let program = Path::new(program);
     // Resolve the initial executable through the same merged view the
     // guest's own syscalls will see: an attached filesystem may have replaced
     // or deleted the program, its script, or its interpreter, and the session
@@ -148,12 +171,6 @@ fn run(mut cmd: RunCmd) -> ExitCode {
             eprintln!("chimera: {err}");
             ExitCode::FAILURE
         }
-    }
-}
-
-fn default_program(argv: &mut Vec<String>) {
-    if argv.is_empty() {
-        argv.push("/bin/bash".into());
     }
 }
 

--- a/cli/opts.rs
+++ b/cli/opts.rs
@@ -103,6 +103,10 @@ pub struct RunCmd {
     #[argh(switch, long = "unsafe")]
     pub unsafe_: bool,
 
+    /// leave the default Bash prompt unchanged
+    #[argh(switch)]
+    pub no_prompt: bool,
+
     /// the program and its arguments (default: /bin/bash). Greedy: option
     /// parsing stops at the program token, so the guest's own flags need no `--`
     /// separator.

--- a/cli/prompt.rs
+++ b/cli/prompt.rs
@@ -1,0 +1,123 @@
+//! The prompt Chimera gives the shell it starts on its own.
+//!
+//! An interactive session must not look like the shell that launched it: the
+//! guest's writes land in a filesystem's delta, or, under `--unsafe`, on the
+//! host itself. Bash takes its prompt setup from an rc file, so Chimera writes
+//! one naming the filesystem that receives the session's writes and hands it
+//! over as `--rcfile`.
+//!
+//! Injecting an rc file, rather than exporting `PS1` or `PROMPT_COMMAND`, is
+//! what makes the badge survive: the file replaces the rc entry point and
+//! sources the user's own `.bashrc` from inside, so a prompt set there cannot
+//! overwrite the badge the way it overwrites an inherited variable.
+
+use std::{
+    env,
+    fs::{self, DirBuilder},
+    io,
+    os::unix::fs::DirBuilderExt,
+    path::PathBuf,
+    process,
+};
+
+use crate::fs::{Filesystem, fresh_id};
+
+/// How much of a filesystem name the badge shows. A generated id is far
+/// shorter; an attach selector naming a path can be arbitrarily long, and the
+/// prompt is a label, not a location.
+const BADGE_MAX: usize = 16;
+
+/// A session's rc file, and the directory that holds it. Dropping this removes
+/// both, so the value lives as long as the guest may read the file.
+pub struct Prompt {
+    dir: PathBuf,
+    /// The process that created the directory. Guest fork is a host fork, so
+    /// every child of the guest tree returns through the CLI carrying a copy
+    /// of this struct; only the creator may remove a tree the rest of the
+    /// session is still using.
+    owner: u32,
+}
+
+impl Prompt {
+    /// Write the rc file for a shell Chimera started itself. It sources the
+    /// user's `.bashrc` and then badges the prompt with `fsys`, or with
+    /// `unsafe` when there is no filesystem and writes reach the host.
+    pub fn new(fsys: Option<&Filesystem>) -> io::Result<Prompt> {
+        let base = env::temp_dir();
+        loop {
+            let dir = base.join(format!("chimera-prompt-{}", fresh_id()?));
+            // An unguessable name created exclusively, in a directory no one
+            // else may write: Bash runs what this holds as the user, so a
+            // predictable path on a shared `/tmp` would be an invitation to
+            // plant the rc file first.
+            match DirBuilder::new().mode(0o700).create(&dir) {
+                Ok(()) => {
+                    let prompt = Prompt {
+                        dir,
+                        owner: process::id(),
+                    };
+                    fs::write(prompt.rcfile(), script(fsys))?;
+                    return Ok(prompt);
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// The path to hand Bash as `--rcfile`. The guest reads it through its own
+    /// namespace, where the host's `/tmp` shows through the overlay's lower
+    /// layer unchanged.
+    pub fn rcfile(&self) -> PathBuf {
+        self.dir.join("bashrc")
+    }
+}
+
+impl Drop for Prompt {
+    fn drop(&mut self) {
+        if process::id() == self.owner {
+            let _ = fs::remove_dir_all(&self.dir);
+        }
+    }
+}
+
+fn script(fsys: Option<&Filesystem>) -> String {
+    let (color, badge) = match fsys {
+        // Reverse video reads as a badge under both light and dark themes.
+        Some(fsys) => ("7", badge(fsys)),
+        // Writes reach the host, which is worth the one alarming color.
+        None => ("97;41", "unsafe".to_string()),
+    };
+    format!(
+        r#"if [[ -n ${{HOME-}} && -r $HOME/.bashrc ]]; then
+    builtin source "$HOME/.bashrc"
+fi
+
+if [[ ${{TERM-}} != dumb && -z ${{NO_COLOR+x}} ]]; then
+    PS1='\[\e[{color}m\] {badge} \[\e[0m\] \w \$ '
+else
+    PS1='[{badge}] \w \$ '
+fi
+"#
+    )
+}
+
+/// The filesystem's name as it can stand inside the single-quoted `PS1`
+/// assignment: an attach selector carries whatever the user typed, so keep
+/// the portable filename characters and replace everything else.
+fn badge(fsys: &Filesystem) -> String {
+    let name = fsys.root.file_name().unwrap_or(fsys.id.as_ref());
+    let badge: String = name
+        .to_string_lossy()
+        .chars()
+        .take(BADGE_MAX)
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '?'
+            }
+        })
+        .collect();
+    if badge.is_empty() { "?".into() } else { badge }
+}


### PR DESCRIPTION
`chimera run` opened Bash with the host's ordinary prompt, leaving an interactive session visually indistinguishable from the shell that launched it. That made it easy to forget which filesystem receives writes, especially when moving between isolated and `--unsafe` sessions.

Give only the implicit Bash command an injected rc file, held in a close-on-exec memfd so prompt setup creates no file in the guest namespace. The rc file sources `.bashrc`, then prefixes the prompt with a theme-neutral, reverse-video filesystem id. The `unsafe` mode gets an explicit red badge. Dumb terminals and `NO_COLOR` receive bracketed plain text, explicit programs remain untouched, and `--no-prompt` restores ordinary Bash behavior.

Unit tests cover command selection and both prompt variants. `cargo test` and Clippy pass for `chimera-cli`; release-mode interactive runs verified the filesystem badge and the corrected Bash escape handling.