### PR TITLE
Introduce container-image base filesystems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +49,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,14 +65,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "chimera-cli"
 version = "0.0.1"
 dependencies = [
  "argh",
  "chimera-runtime",
+ "flate2",
  "libc",
  "mimalloc",
+ "serde_json",
  "shlex",
+ "tar",
 ]
 
 [[package]]
@@ -76,10 +97,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "iced-x86"
@@ -89,6 +149,12 @@ checksum = "7c447cff8c7f384a7d4f741cfcff32f75f3ad02b406432e8d6c878d56b1edf6b"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -112,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +196,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -174,6 +256,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,10 +299,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "syn"
@@ -218,6 +332,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -245,3 +370,34 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -180,29 +180,57 @@ not even a change-set that ended up empty, because you may well have branched
 precisely in order to have somewhere to stand. `--rm` is the one and only
 thing that discards, and you have to ask for it.
 
+### Image filesystems
+
+A container image can serve where the live host does: as the tree a sandbox
+reads through. `chimera fs pull docker:debian:13-slim` fetches the image from
+its registry, flattens its layers into one complete tree, and keeps the
+result as an *image filesystem* — a filesystem like any other, with an id in
+`fs list`, except that it descends from nothing (`-` in the FROM column) and
+is immutable. `--from docker:debian:13-slim` does the same resolution — the
+pull happens on first use, later runs reuse the kept image — and branches
+the result, so the guest sees the image's Debian tree at `/` while its writes
+land in the run's change-set, exactly as a host-rooted run's land over the
+live host.
+
+Because the image is immutable, a branch references it rather than copying
+it: branches are cheap regardless of image size, and `fs rm` refuses to
+remove an image that kept filesystems still stack on. Everything relative is
+reinterpreted against the image: `fs diff` of an image-rooted filesystem
+compares with the image's tree, and `fs apply` is refused — the changes are
+relative to the image, and pasting them onto the host would be nonsense.
+`/proc`, `/sys`, and `/dev` come from the running host, since they are
+interfaces to the kernel rather than content an image could carry; everything
+else the guest sees is the image's. A session starts at `/`, the image's
+root, and the guest keeps your environment variables.
+
+Only public images pull today (the anonymous token flow — Docker Hub, GHCR,
+and any distribution-spec registry), the transport borrows `curl(1)`, and a
+moved tag is refreshed by removing the old image filesystem and pulling
+again.
+
 ### Naming filesystems
 
 How a filesystem is named is independent of what you do with it. A *locator*
 names one; the verb — `--from` or `--in` — decides whether it is branched or
-resumed. Three forms exist today:
+resumed. Four forms exist today:
 
 | Locator | Names | Notes |
 | --- | --- | --- |
 | `host` | The live host tree | Only ever a branch point: `--from host` is the default spelled out, `--in host` is refused — that operation is `--unsafe`. |
 | An id | A kept filesystem | 8 hex characters — what `fs list` prints and what the kept notice hands you. The normal currency. |
 | A path | A change-set directory, directly | Anything containing `/`. `--in` creates it on first use. Raw state, yours to manage — see [Pin a filesystem in scripts](#pin-a-filesystem-in-scripts). |
+| `docker:<image>` | A container image | Docker reference rules: `docker:debian:13-slim`, `docker:ghcr.io/acme/tool:v2`, `@sha256:...` to pin. Resolves to the kept image filesystem, pulling on first use. Branch-only, like `host`. |
 
-`--from` accepts all three, and every `fs` subcommand accepts an id or a
+`--from` accepts all four, and every `fs` subcommand accepts an id or a
 path. `--in` accepts only what can be written to: an id or a path, never
-`host`.
+`host` and never an image.
 
-Locators of the form `<word>:...` are reserved for filesystems that do not
-live on this machine — a container image, a remote change-set. A leading
-scheme is recognized before anything else, so adding them later cannot change
-how a path or an id is read. Such a source may well be immutable, as a
-container image is: it can be branched with `--from` and never resumed with
-`--in`. A path whose first component contains a colon needs a leading `./` to
-be read as a path.
+Locator schemes other than `docker:` — the rest of the `<word>:...` space —
+remain reserved for filesystems that do not live on this machine. A leading
+scheme is recognized before anything else, so adding one cannot change how a
+path or an id is read; a path whose first component contains a colon needs a
+leading `./` to be read as a path.
 
 ## How to
 
@@ -252,7 +280,8 @@ Naming no program starts `/bin/bash`. Chimera hands the shell an rc file that
 sources your own `~/.bashrc` and then badges the prompt with the filesystem
 the session writes into — `unsafe`, on a red field, under `--unsafe` — so the
 badge survives a `PS1` set in your dotfiles. Pass `--no-prompt` to leave the
-prompt alone.
+prompt alone. An image-rooted session runs the image's own `/bin/bash` with
+no badge yet: the rc file lives on the host, outside the guest's tree.
 
 ### Resume a session
 
@@ -273,6 +302,42 @@ modifies, a run that takes one from the environment announces it:
 $ export CHIMERA_FS=51fad6cd
 $ chimera run make install
 chimera: --in 51fad6cd (CHIMERA_FS)
+```
+
+### Base a sandbox on a container image
+
+Name an image as the branch point and the guest runs against that image's
+tree instead of the live host — same CoW model, different base:
+
+```console
+$ chimera run --from docker:debian:13-slim
+chimera: pulling docker:docker.io/library/debian:13-slim
+chimera:   layer 1/1 (28M)
+chimera: pulled docker:docker.io/library/debian:13-slim as 56ffafdf
+bash-5.2$ cat /etc/os-release | head -1
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
+```
+
+The pull happens once; the image is now filesystem `56ffafdf`, and every
+later `--from docker:debian:13-slim` — or `--from 56ffafdf`, the same thing —
+branches it without touching the network.
+
+This composes with branch-and-resume into image baking without an image
+build system: run the setup commands once, keep the result, and fan out.
+
+```console
+$ chimera run --from docker:debian:13-slim apt-get install -y build-essential
+chimera: filesystem kept; continue with:
+  chimera run --in 51fad6cd
+$ chimera run --rm --from 51fad6cd make test    # each agent branches the baked base
+```
+
+To pin the exact image in a script regardless of where the tag moves later,
+capture the id `fs pull` prints:
+
+```console
+$ base=$(chimera fs pull docker:debian:13-slim)
+$ chimera run --from "$base" ...
 ```
 
 ### Experiment without risk
@@ -390,8 +455,8 @@ Options are spelled `--name value`, not `--name=value`.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `--from`, `-f` `<filesystem>` | `host` | Branch point: `host`, a kept filesystem's id, or a path to a change-set directory. The named filesystem is left exactly as it was. |
-| `--in <filesystem>` | | Resume an existing filesystem: an id or a path, never `host`. Changes accumulate into it rather than into a new one. Defaults from `CHIMERA_FS`. |
+| `--from`, `-f` `<filesystem>` | `host` | Branch point: `host`, a kept filesystem's id, a path to a change-set directory, or a `docker:` image (pulled on first use). The named filesystem is left exactly as it was. |
+| `--in <filesystem>` | | Resume an existing filesystem: an id or a path, never `host` and never an image. Changes accumulate into it rather than into a new one. Defaults from `CHIMERA_FS`. |
 | `--rm` | | Discard the new filesystem when the run exits. Only meaningful when branching; refused with `--in`, where it would destroy a filesystem you had deliberately kept. |
 | `--unsafe` | | No filesystem at all; the guest mutates the live host. Contradicts `--from`, `--in`, and `--rm`. |
 | `--no-prompt` | | Leave the started shell's prompt alone instead of badging it. |
@@ -445,9 +510,19 @@ because it is a copy rather than a reference, later resuming the source with
 `--in` cannot disturb anything already branched from it. Branch from a
 quiesced source: a live session still writing into it can tear the snapshot.
 
+#### `chimera fs pull <image>`
+
+Fetch a container image (`docker:` locators only) and keep it as an image
+filesystem; prints the id on stdout, so `chimera run --from $(chimera fs
+pull docker:debian:13-slim)` scripts cleanly and stays pinned to the digest
+the pull resolved. An image already kept — matched by digest when the
+locator pins one, by normalized reference otherwise — prints its existing id
+without touching the network. Needs `curl(1)` and `sha256sum(1)` on `PATH`.
+
 #### `chimera fs rm <filesystem>...`
 
-Remove filesystems. Refused while any live session holds one.
+Remove filesystems. Refused while any live session holds one, and for an
+image filesystem that kept filesystems still branch from.
 
 #### `chimera fs prune`
 
@@ -479,9 +554,10 @@ Kept filesystems live under `$XDG_STATE_HOME/chimera/fs` (defaulting to
 
 | Entry | Contents |
 | --- | --- |
-| `data/` | The change-set itself, in the format the runtime owns. |
+| `data/` | The change-set itself, in the format the runtime owns. For an image filesystem, the image's complete flattened tree. |
 | `tmp/` | Staging space. |
-| `meta` | Human-readable provenance — informational only, including the `parent` line a branch records. |
+| `meta` | Human-readable provenance — informational only, including the `parent` line a branch records and the `image`/`digest` lines a pull records. |
+| `base` | For a filesystem that branched an image: the image filesystem its change-set is relative to. Load-bearing, unlike `meta`. |
 | `lock` | Coordinates live sessions and removal. |
 
 The change-set encodes deletions and metadata in user extended attributes, so

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,9 @@ path = "main.rs"
 [dependencies]
 chimera-runtime = { path = "../runtime" }
 argh = "0.1.19"
+flate2 = "1"
 libc = "0.2"
 mimalloc = "0.1.52"
+serde_json = "1"
 shlex = "1.3.0"
+tar = "0.4"

--- a/cli/docker.rs
+++ b/cli/docker.rs
@@ -1,0 +1,691 @@
+//! `docker:` image pull: fetch a container image from an OCI registry and
+//! keep it as an image filesystem — a complete base tree with no parent.
+//!
+//! The pull flattens the image's layer stack at fetch time: each layer tar is
+//! applied in order onto one staged tree, OCI whiteouts included, so by the
+//! time the filesystem exists the runtime never sees layers at all. The tree
+//! then serves as an overlay *lower*, exactly the role the live host plays
+//! for an ordinary filesystem, which is why nothing downstream of the pull
+//! needs to know images exist.
+//!
+//! Transport is `curl(1)` and digests are checked with `sha256sum(1)`: the
+//! registry protocol is a handful of HTTPS GETs, and borrowing the system
+//! tools keeps a TLS stack out of Chimera's build. Only the anonymous Bearer
+//! token flow is spoken, which covers public images on Docker Hub, GHCR, and
+//! any other distribution-spec registry.
+
+use std::{
+    fs,
+    io::{self, Read},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::fs::{adopt_image_root, find_image_root, staging_dir};
+
+/// A parsed `docker:` locator, normalized the way Docker normalizes
+/// references: a bare name gains `docker.io/library/`, a missing tag reads as
+/// `latest`. `reference` is what the manifest is fetched by — a tag, or a
+/// `sha256:` digest when the locator pinned one.
+struct ImageRef {
+    /// Registry host as named in the reference (`docker.io`, `ghcr.io`, …).
+    registry: String,
+    repository: String,
+    reference: String,
+    /// The normalized locator, e.g. `docker:docker.io/library/debian:13-slim`
+    /// — the identity two differently-typed locators for the same image agree
+    /// on, recorded in provenance and matched on re-pull.
+    canonical: String,
+}
+
+impl ImageRef {
+    fn parse(locator: &str) -> io::Result<ImageRef> {
+        let Some(rest) = locator.strip_prefix("docker:") else {
+            return Err(invalid(format!(
+                "not a docker: locator: {locator} (try docker:{locator})"
+            )));
+        };
+        let (name, digest) = match rest.split_once('@') {
+            Some((name, digest)) => {
+                if !digest.starts_with("sha256:") {
+                    return Err(invalid(format!("unsupported digest in {locator}")));
+                }
+                (name, Some(digest))
+            }
+            None => (rest, None),
+        };
+        // Docker's own registry heuristic: the first component names a
+        // registry only when it can't be a repository name — it contains a
+        // dot or a port, or is exactly `localhost`.
+        let (registry, path) = match name.split_once('/') {
+            Some((first, path))
+                if first.contains('.') || first.contains(':') || first == "localhost" =>
+            {
+                (first.to_string(), path.to_string())
+            }
+            _ => ("docker.io".to_string(), name.to_string()),
+        };
+        // The tag is the part after a colon in the *last* component; earlier
+        // colons can only be the registry's port, consumed above.
+        let (repository, tag) = match path.rsplit_once(':') {
+            Some((repo, tag)) if !tag.contains('/') => (repo.to_string(), tag.to_string()),
+            _ => (path, "latest".to_string()),
+        };
+        if repository.is_empty() {
+            return Err(invalid(format!("no repository in {locator}")));
+        }
+        let repository = if registry == "docker.io" && !repository.contains('/') {
+            format!("library/{repository}")
+        } else {
+            repository
+        };
+        let canonical = match digest {
+            Some(digest) => format!("docker:{registry}/{repository}@{digest}"),
+            None => format!("docker:{registry}/{repository}:{tag}"),
+        };
+        Ok(ImageRef {
+            registry,
+            repository,
+            reference: digest.map(str::to_string).unwrap_or(tag),
+            canonical,
+        })
+    }
+
+    /// The API host: Docker Hub's registry lives at `registry-1.docker.io`,
+    /// its user-facing name notwithstanding.
+    fn api_host(&self) -> &str {
+        if self.registry == "docker.io" {
+            "registry-1.docker.io"
+        } else {
+            &self.registry
+        }
+    }
+
+    fn pinned_digest(&self) -> Option<&str> {
+        self.reference
+            .starts_with("sha256:")
+            .then_some(self.reference.as_str())
+    }
+}
+
+fn invalid(msg: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, msg)
+}
+
+/// Resolve a `docker:` locator to an image filesystem's id, pulling the image
+/// if no kept filesystem matches it. The match is by digest when the locator
+/// pins one and by normalized reference otherwise, so re-running a `--from`
+/// costs no network; refreshing a moved tag is a `fs rm` of the old root and
+/// a new pull.
+pub fn pull(locator: &str) -> io::Result<String> {
+    let image = ImageRef::parse(locator)?;
+    if let Some(id) = find_image_root(&image.canonical, image.pinned_digest()) {
+        return Ok(id);
+    }
+    eprintln!("chimera: pulling {}", image.canonical);
+    let stage = Staging::new()?;
+    let (digest, layers) = fetch_manifest(&image)?;
+    let data = stage.dir.join("data");
+    fs::create_dir(&data)?;
+    for (i, layer) in layers.iter().enumerate() {
+        eprintln!(
+            "chimera:   layer {}/{} ({})",
+            i + 1,
+            layers.len(),
+            human_size(layer.size),
+        );
+        let blob = stage.dir.join("layer");
+        fetch_blob(&image, &layer.digest, &blob)?;
+        apply_layer(&blob, &layer.media_type, &data)?;
+        fs::remove_file(&blob)?;
+    }
+    let id = adopt_image_root(&stage.dir, locator, &image.canonical, &digest)?;
+    eprintln!("chimera: pulled {} as {id}", image.canonical);
+    Ok(id)
+}
+
+/// The staging directory a pull assembles the tree in, removed on failure —
+/// an aborted pull must not leave a half-image where the next run finds it.
+struct Staging {
+    dir: PathBuf,
+    keep: bool,
+}
+
+impl Staging {
+    fn new() -> io::Result<Staging> {
+        let base = staging_dir();
+        fs::create_dir_all(&base)?;
+        loop {
+            let dir = base.join(crate::fs::fresh_id()?);
+            match fs::create_dir(&dir) {
+                Ok(()) => return Ok(Staging { dir, keep: false }),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+impl Drop for Staging {
+    fn drop(&mut self) {
+        if !self.keep {
+            let _ = fs::remove_dir_all(&self.dir);
+        }
+    }
+}
+
+struct Layer {
+    digest: String,
+    media_type: String,
+    size: u64,
+}
+
+/// Fetch the image's manifest, stepping through a multi-platform index to the
+/// linux/amd64 entry, and return the manifest digest with the layer list.
+fn fetch_manifest(image: &ImageRef) -> io::Result<(String, Vec<Layer>)> {
+    const ACCEPT: &str = "application/vnd.oci.image.index.v1+json, \
+         application/vnd.docker.distribution.manifest.list.v2+json, \
+         application/vnd.oci.image.manifest.v1+json, \
+         application/vnd.docker.distribution.manifest.v2+json";
+
+    let token = token(image)?;
+    let get = |reference: &str| -> io::Result<(serde_json::Value, String)> {
+        let url = format!(
+            "https://{}/v2/{}/manifests/{}",
+            image.api_host(),
+            image.repository,
+            reference,
+        );
+        let body = http_get(&url, ACCEPT, token.as_deref(), None)?;
+        let digest = format!("sha256:{}", sha256(&body)?);
+        if reference.starts_with("sha256:") && digest != reference {
+            return Err(io::Error::other(format!(
+                "manifest digest mismatch for {url}: got {digest}"
+            )));
+        }
+        let json = serde_json::from_slice(&body)
+            .map_err(|e| io::Error::other(format!("bad manifest from {url}: {e}")))?;
+        Ok((json, digest))
+    };
+
+    let (mut manifest, mut digest) = get(&image.reference)?;
+    if manifest.get("layers").is_none() {
+        // A multi-platform index: descend into the linux/amd64 manifest. Its
+        // digest is the identity recorded — the platform image is what the
+        // filesystem holds.
+        let entry = manifest["manifests"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .find(|m| {
+                m["platform"]["os"].as_str() == Some("linux")
+                    && m["platform"]["architecture"].as_str() == Some("amd64")
+            })
+            .and_then(|m| m["digest"].as_str())
+            .ok_or_else(|| io::Error::other(format!("{}: no linux/amd64 image", image.canonical)))?
+            .to_string();
+        (manifest, digest) = get(&entry)?;
+    }
+    let layers = manifest["layers"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .map(|l| {
+            Ok(Layer {
+                digest: l["digest"]
+                    .as_str()
+                    .ok_or_else(|| io::Error::other("layer without digest"))?
+                    .to_string(),
+                media_type: l["mediaType"].as_str().unwrap_or_default().to_string(),
+                size: l["size"].as_u64().unwrap_or(0),
+            })
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    if layers.is_empty() {
+        return Err(io::Error::other(format!(
+            "{}: manifest names no layers",
+            image.canonical
+        )));
+    }
+    Ok((digest, layers))
+}
+
+fn fetch_blob(image: &ImageRef, digest: &str, out: &Path) -> io::Result<()> {
+    let token = token(image)?;
+    let url = format!(
+        "https://{}/v2/{}/blobs/{digest}",
+        image.api_host(),
+        image.repository,
+    );
+    http_get(
+        &url,
+        "application/octet-stream",
+        token.as_deref(),
+        Some(out),
+    )?;
+    let got = sha256_file(out)?;
+    if format!("sha256:{got}") != digest {
+        return Err(io::Error::other(format!(
+            "layer digest mismatch for {url}: got sha256:{got}"
+        )));
+    }
+    Ok(())
+}
+
+/// An anonymous pull token, by the distribution-spec challenge flow: probe
+/// `/v2/`, and on a Bearer challenge ask the named realm for a pull-scoped
+/// token with no credentials. `None` when the registry never challenged.
+fn token(image: &ImageRef) -> io::Result<Option<String>> {
+    let probe = format!("https://{}/v2/", image.api_host());
+    let response = curl(&probe, &[], None)?;
+    if response.status != 401 {
+        return Ok(None);
+    }
+    let challenge = response
+        .headers
+        .iter()
+        .find_map(|(name, value)| {
+            name.eq_ignore_ascii_case("www-authenticate")
+                .then_some(value.as_str())
+        })
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or_else(|| io::Error::other(format!("{probe}: unsupported auth challenge")))?;
+    let field = |name: &str| {
+        challenge.split(',').find_map(|part| {
+            part.trim()
+                .strip_prefix(name)?
+                .strip_prefix("=\"")?
+                .strip_suffix('"')
+                .map(str::to_string)
+        })
+    };
+    let realm = field("realm")
+        .ok_or_else(|| io::Error::other(format!("{probe}: auth challenge names no realm")))?;
+    let mut url = format!("{realm}?scope=repository:{}:pull", image.repository);
+    if let Some(service) = field("service") {
+        url.push_str(&format!("&service={service}"));
+    }
+    let body = http_get(&url, "application/json", None, None)?;
+    let json: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|e| io::Error::other(format!("bad token response from {url}: {e}")))?;
+    let token = json["token"]
+        .as_str()
+        .or_else(|| json["access_token"].as_str())
+        .ok_or_else(|| io::Error::other(format!("no token in response from {url}")))?;
+    Ok(Some(token.to_string()))
+}
+
+/// GET `url`, failing on any non-2xx status. With `out` the body streams to
+/// that file (and an empty Vec returns); otherwise the body is the result.
+fn http_get(
+    url: &str,
+    accept: &str,
+    token: Option<&str>,
+    out: Option<&Path>,
+) -> io::Result<Vec<u8>> {
+    let mut headers = vec![format!("Accept: {accept}")];
+    if let Some(token) = token {
+        headers.push(format!("Authorization: Bearer {token}"));
+    }
+    let response = curl(url, &headers, out)?;
+    if !(200..300).contains(&response.status) {
+        return Err(io::Error::other(format!("{url}: HTTP {}", response.status)));
+    }
+    Ok(response.body)
+}
+
+/// A completed exchange: the final status, the final response's headers, and
+/// the body — empty when it streamed to a file instead.
+struct Response {
+    status: u32,
+    headers: Vec<(String, String)>,
+    body: Vec<u8>,
+}
+
+/// One `curl(1)` request: follows redirects (a registry hands blob GETs off
+/// to a CDN; curl itself drops the Authorization header on a cross-host hop),
+/// keeping the final response. The body lands in `out` when given.
+fn curl(url: &str, headers: &[String], out: Option<&Path>) -> io::Result<Response> {
+    let mut cmd = Command::new("curl");
+    cmd.args(["-sS", "-L", "--connect-timeout", "30", "-D", "-"]);
+    for header in headers {
+        cmd.args(["-H", header]);
+    }
+    match out {
+        Some(path) => cmd.arg("-o").arg(path),
+        // The body follows the header dump on stdout; a blank line ends the
+        // final header block, so the split below is unambiguous.
+        None => cmd.arg("-o").arg("/dev/stdout"),
+    };
+    cmd.arg(url);
+    let output = cmd.output().map_err(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            io::Error::new(e.kind(), "pulling an image needs curl(1) on PATH")
+        } else {
+            e
+        }
+    })?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "curl {url}: {}",
+            String::from_utf8_lossy(&output.stderr).trim(),
+        )));
+    }
+    // Each hop of a redirect chain dumps its own header block; the last block
+    // describes the response the body came from.
+    let stdout = output.stdout;
+    let mut cursor = 0;
+    let mut status = 0u32;
+    let mut headers = Vec::new();
+    while stdout[cursor..].starts_with(b"HTTP/") {
+        let Some(end) = find(&stdout[cursor..], b"\r\n\r\n") else {
+            break;
+        };
+        let block = &stdout[cursor..cursor + end];
+        cursor += end + 4;
+        let mut lines = block.split(|&b| b == b'\r');
+        status = lines
+            .next()
+            .and_then(|l| {
+                String::from_utf8_lossy(l)
+                    .split_whitespace()
+                    .nth(1)?
+                    .parse()
+                    .ok()
+            })
+            .unwrap_or(0);
+        headers = block
+            .split(|&b| b == b'\n')
+            .filter_map(|line| {
+                let line = String::from_utf8_lossy(line);
+                let (name, value) = line.trim_end_matches('\r').split_once(':')?;
+                Some((name.trim().to_string(), value.trim().to_string()))
+            })
+            .collect();
+        // An informational response (100 Continue) precedes the real one.
+        if (100..200).contains(&status) {
+            continue;
+        }
+        if (300..400).contains(&status) {
+            continue;
+        }
+        break;
+    }
+    Ok(Response {
+        status,
+        headers,
+        body: stdout[cursor.min(stdout.len())..].to_vec(),
+    })
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn sha256(bytes: &[u8]) -> io::Result<String> {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let mut child = Command::new("sha256sum")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                io::Error::new(e.kind(), "pulling an image needs sha256sum(1) on PATH")
+            } else {
+                e
+            }
+        })?;
+    child.stdin.take().expect("piped stdin").write_all(bytes)?;
+    digest_from(child.wait_with_output()?)
+}
+
+fn sha256_file(path: &Path) -> io::Result<String> {
+    let output = Command::new("sha256sum").arg(path).output()?;
+    digest_from(output)
+}
+
+fn digest_from(output: std::process::Output) -> io::Result<String> {
+    if !output.status.success() {
+        return Err(io::Error::other("sha256sum failed"));
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+        .ok_or_else(|| io::Error::other("sha256sum produced no digest"))
+}
+
+/// Apply one layer tar onto the staged tree. Two passes, whiteouts first:
+/// the OCI spec asks producers to order whiteouts ahead of their siblings
+/// but consumers not to depend on it, and a second decompression is cheap
+/// next to the download.
+fn apply_layer(blob: &Path, media_type: &str, data: &Path) -> io::Result<()> {
+    let mut skipped = 0u32;
+    for entry in archive(blob, media_type)?.entries()? {
+        let entry = entry?;
+        match classify(&entry.path()?) {
+            LayerEntry::Opaque(dir) => {
+                // The directory replaces its lower content wholesale; what
+                // this same layer puts back arrives in the content pass.
+                let Some(dir) = staged_path(data, &dir) else {
+                    skipped += 1;
+                    continue;
+                };
+                if dir != data {
+                    remove(&dir)?;
+                    fs::create_dir_all(&dir)?;
+                }
+            }
+            LayerEntry::Whiteout(victim) => {
+                let Some(victim) = staged_path(data, &victim) else {
+                    skipped += 1;
+                    continue;
+                };
+                if victim != data {
+                    remove(&victim)?;
+                }
+            }
+            LayerEntry::Content => {}
+        }
+    }
+    for entry in archive(blob, media_type)?.entries()? {
+        let mut entry = entry?;
+        let rel = entry.path()?.into_owned();
+        if !matches!(classify(&rel), LayerEntry::Content) {
+            continue;
+        }
+        use tar::EntryType;
+        match entry.header().entry_type() {
+            // Device nodes need privilege the sandbox deliberately lacks,
+            // and the host's /dev serves the guest anyway.
+            EntryType::Char | EntryType::Block => continue,
+            _ => {}
+        }
+        // A later layer may change an entry's type; tar itself only
+        // overwrites same-type entries, so clear the slot first. An existing
+        // directory stays for a directory entry — its children are already
+        // merged content.
+        if let Some(target) = staged_path(data, &rel)
+            && target != data
+        {
+            match fs::symlink_metadata(&target) {
+                Ok(md) if md.is_dir() && entry.header().entry_type() == EntryType::Directory => {}
+                Ok(_) => remove(&target)?,
+                Err(_) => {}
+            }
+        }
+        if !entry.unpack_in(data)? {
+            skipped += 1;
+        }
+    }
+    if skipped > 0 {
+        eprintln!("chimera:   skipped {skipped} unsafe path(s) in layer");
+    }
+    Ok(())
+}
+
+/// The staged location of a layer-relative path, or `None` when acting on it
+/// could reach outside the stage: a climbing component, or an intermediate
+/// that resolves through a symlink — a layer that stages `usr` as an absolute
+/// symlink and then whiteouts `usr/bin` must not delete the host's. The tar
+/// crate's `unpack_in` enforces the same rule for extraction; this covers the
+/// removals this module does itself.
+fn staged_path(data: &Path, rel: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+
+    let mut out = data.to_path_buf();
+    for c in rel.components() {
+        match c {
+            Component::CurDir => {}
+            Component::Normal(name) => {
+                match fs::symlink_metadata(&out) {
+                    Ok(md) if md.file_type().is_symlink() => return None,
+                    _ => {}
+                }
+                out.push(name);
+            }
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(out)
+}
+
+fn remove(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(md) if md.is_dir() => fs::remove_dir_all(path),
+        Ok(_) => fs::remove_file(path),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn archive(blob: &Path, media_type: &str) -> io::Result<tar::Archive<Box<dyn Read>>> {
+    let file = fs::File::open(blob)?;
+    let reader: Box<dyn Read> = if media_type.contains("zstd") {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("zstd-compressed layers are not supported yet ({media_type})"),
+        ));
+    } else if media_type.contains("gzip") {
+        Box::new(flate2::read::MultiGzDecoder::new(file))
+    } else {
+        Box::new(file)
+    };
+    let mut archive = tar::Archive::new(reader);
+    archive.set_preserve_permissions(true);
+    archive.set_preserve_ownerships(false);
+    archive.set_unpack_xattrs(false);
+    Ok(archive)
+}
+
+/// What a layer tar entry means for the flattened tree, by the OCI whiteout
+/// convention: `.wh..wh..opq` marks its directory opaque, any other `.wh.`
+/// prefix deletes the named sibling.
+enum LayerEntry {
+    Opaque(PathBuf),
+    Whiteout(PathBuf),
+    Content,
+}
+
+fn classify(rel: &Path) -> LayerEntry {
+    let Some(name) = rel.file_name().and_then(|n| n.to_str()) else {
+        return LayerEntry::Content;
+    };
+    let parent = rel.parent().unwrap_or(Path::new(""));
+    if name == ".wh..wh..opq" {
+        LayerEntry::Opaque(parent.to_path_buf())
+    } else if let Some(victim) = name.strip_prefix(".wh.") {
+        LayerEntry::Whiteout(parent.join(victim))
+    } else {
+        LayerEntry::Content
+    }
+}
+
+fn human_size(bytes: u64) -> String {
+    match bytes {
+        0..1024 => format!("{bytes}B"),
+        1024..1048576 => format!("{}K", bytes / 1024),
+        1048576..1073741824 => format!("{}M", bytes / 1048576),
+        _ => format!("{}G", bytes / 1073741824),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parts(locator: &str) -> (String, String, String, String) {
+        let r = ImageRef::parse(locator).unwrap();
+        (r.registry, r.repository, r.reference, r.canonical)
+    }
+
+    #[test]
+    fn bare_name_normalizes_to_docker_hub_library() {
+        assert_eq!(
+            parts("docker:debian:13-slim"),
+            (
+                "docker.io".into(),
+                "library/debian".into(),
+                "13-slim".into(),
+                "docker:docker.io/library/debian:13-slim".into(),
+            )
+        );
+    }
+
+    #[test]
+    fn missing_tag_reads_as_latest() {
+        assert_eq!(parts("docker:alpine").2, "latest");
+    }
+
+    #[test]
+    fn registry_host_is_recognized_by_dot() {
+        assert_eq!(
+            parts("docker:ghcr.io/acme/agent:v2"),
+            (
+                "ghcr.io".into(),
+                "acme/agent".into(),
+                "v2".into(),
+                "docker:ghcr.io/acme/agent:v2".into(),
+            )
+        );
+    }
+
+    #[test]
+    fn slash_name_without_host_stays_on_docker_hub() {
+        assert_eq!(parts("docker:penberg/tool:1").1, "penberg/tool".to_string());
+    }
+
+    #[test]
+    fn digest_pins_the_reference() {
+        let digest = "sha256:38a76d01668772e381ad2826d876627c89e7133e2f8a0f5d567306798b0f2a16";
+        let (_, _, reference, canonical) = parts(&format!("docker:debian:13-slim@{digest}"));
+        assert_eq!(reference, digest);
+        assert_eq!(
+            canonical,
+            format!("docker:docker.io/library/debian@{digest}")
+        );
+    }
+
+    #[test]
+    fn locator_without_scheme_is_refused() {
+        assert!(ImageRef::parse("debian:13-slim").is_err());
+    }
+
+    #[test]
+    fn whiteouts_classify_by_the_oci_convention() {
+        assert!(matches!(
+            classify(Path::new("usr/bin/.wh.perl")),
+            LayerEntry::Whiteout(p) if p == Path::new("usr/bin/perl")
+        ));
+        assert!(matches!(
+            classify(Path::new("etc/apt/.wh..wh..opq")),
+            LayerEntry::Opaque(p) if p == Path::new("etc/apt")
+        ));
+        assert!(matches!(
+            classify(Path::new("usr/bin/perl")),
+            LayerEntry::Content
+        ));
+    }
+}

--- a/cli/fs.rs
+++ b/cli/fs.rs
@@ -74,6 +74,121 @@ fn filesystems_dir() -> PathBuf {
     state.join("chimera/fs")
 }
 
+/// Where a pull assembles an image tree before it becomes a filesystem: a
+/// sibling of the filesystems directory, so the final move is a rename on
+/// one mount and a crashed pull never leaves a half-image where `list` or a
+/// run could find it.
+pub fn staging_dir() -> PathBuf {
+    filesystems_dir().with_file_name("pull")
+}
+
+/// Keep a staged image tree (`stage` holds its `data/`) as an image
+/// filesystem under a fresh id. An image filesystem is a complete base tree
+/// with no parent: `image` and `digest` become its provenance, and its
+/// immutability — resume is refused, a branch stacks on it by reference —
+/// is what lets that provenance stay true.
+pub fn adopt_image_root(
+    stage: &Path,
+    locator: &str,
+    canonical: &str,
+    digest: &str,
+) -> io::Result<String> {
+    use std::io::Write as _;
+
+    let base = filesystems_dir();
+    fs::create_dir_all(&base)?;
+    loop {
+        let id = fresh_id()?;
+        let root = base.join(&id);
+        match fs::rename(stage, &root) {
+            Ok(()) => {
+                write_meta(&root, &id, locator)?;
+                let mut meta = fs::OpenOptions::new()
+                    .append(true)
+                    .open(root.join("meta"))?;
+                writeln!(meta, "image = {canonical}\ndigest = {digest}")?;
+                return Ok(id);
+            }
+            // The fresh id lost a birth race; try another.
+            Err(e) if root.exists() && e.kind() != io::ErrorKind::NotFound => {
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// The kept image filesystem matching a normalized reference — by digest when
+/// the locator pinned one, by reference otherwise — newest first when a
+/// re-pulled tag left several roots behind.
+pub fn find_image_root(canonical: &str, digest: Option<&str>) -> Option<String> {
+    let entries = fs::read_dir(filesystems_dir()).ok()?;
+    entries
+        .filter_map(Result::ok)
+        .filter(|e| e.path().join("data").is_dir())
+        .filter(|e| {
+            let root = e.path();
+            match digest {
+                Some(digest) => meta_field(&root, "digest").as_deref() == Some(digest),
+                None => meta_field(&root, "image").as_deref() == Some(canonical),
+            }
+        })
+        .max_by_key(|e| created(&e.path()))
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+}
+
+/// One field of a filesystem's provenance record.
+fn meta_field(root: &Path, name: &str) -> Option<String> {
+    let meta = fs::read_to_string(root.join("meta")).ok()?;
+    let value = meta
+        .lines()
+        .find_map(|l| l.strip_prefix(name)?.trim_start().strip_prefix('='))?
+        .trim()
+        .to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// The normalized image reference of an image filesystem, `None` for an
+/// ordinary change-set.
+pub fn image_of(root: &Path) -> Option<String> {
+    meta_field(root, "image")
+}
+
+/// The image filesystem a branch's change-set is relative to: the content of
+/// its `base` file. Absent for a filesystem whose lower is the live host.
+/// Unlike the informational `meta`, this record is load-bearing — it is how
+/// a run finds the tree to mount under the delta.
+pub fn base_of(root: &Path) -> Option<String> {
+    let base = fs::read_to_string(root.join("base")).ok()?;
+    let base = base.trim().to_string();
+    (!base.is_empty()).then_some(base)
+}
+
+fn record_base(root: &Path, base: &str) -> io::Result<()> {
+    fs::write(root.join("base"), format!("{base}\n"))
+}
+
+/// An image-rooted session's handle on its base: the tree to serve as the
+/// overlay's lower, plus this session's share of the base's hold so removal
+/// waits for the run.
+pub struct Base {
+    pub data: PathBuf,
+    _hold: OwnedFd,
+}
+
+/// Open the base an image-rooted filesystem stacks on. The named image
+/// filesystem must still exist: a branch references its base rather than
+/// copying it, which `fs rm`'s dependent check preserves.
+pub fn open_base(selector: &str) -> io::Result<Base> {
+    let root = resolve(selector)
+        .map_err(|e| io::Error::new(e.kind(), format!("base image filesystem {selector}: {e}")))?;
+    let hold = hold(&root)?;
+    Ok(Base {
+        data: root.join("data"),
+        _hold: hold,
+    })
+}
+
 /// A fresh filesystem with a collision-free generated id.
 pub fn create(command: &str) -> io::Result<Filesystem> {
     let base = filesystems_dir();
@@ -108,6 +223,7 @@ pub fn create(command: &str) -> io::Result<Filesystem> {
 pub fn attach(selector: &OsStr) -> io::Result<Filesystem> {
     let root = PathBuf::from(selector);
     fs::create_dir_all(&root)?;
+    refuse_image_root(&root)?;
     let hold = hold(&root)?;
     Ok(Filesystem {
         id: selector.to_string_lossy().into_owned(),
@@ -119,10 +235,24 @@ pub fn attach(selector: &OsStr) -> io::Result<Filesystem> {
     })
 }
 
+/// Refuse to open an image filesystem for writing. Its provenance promises
+/// the tree is exactly the pulled image, and every branch stacked on it
+/// reads it live — one resumed session would falsify both.
+fn refuse_image_root(root: &std::path::Path) -> io::Result<()> {
+    match image_of(root) {
+        Some(image) => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("{image} is an image and immutable; branch it with --from"),
+        )),
+        None => Ok(()),
+    }
+}
+
 /// Resume a kept filesystem by id: the change-set itself becomes the run's
 /// working state, so unlike a branch point it must already exist.
 pub fn resume(id: &str) -> io::Result<Filesystem> {
     let root = resolve(id)?;
+    refuse_image_root(&root)?;
     let hold = hold(&root)?;
     Ok(Filesystem {
         id: id.to_string(),
@@ -164,8 +294,25 @@ pub fn branch(selector: &str, command: &str) -> io::Result<Filesystem> {
     let src = resolve(selector)?;
     let _share = hold(&src)?;
     let fsys = create(command)?;
-    let seed = copy_entry(&src.join("data"), &fsys.root.join("data"))
-        .and_then(|()| record_parent(&fsys.root, selector));
+    let seed = if image_of(&src).is_some() {
+        // An image is a complete base tree, not a change-set: the branch
+        // starts with an empty delta — created here, since `data/` existing
+        // is what makes the result a filesystem — and records the image as
+        // the lower its changes are relative to. The reference (rather than
+        // a copy) is safe because the image is immutable, and `rm` refuses
+        // an image that filesystems still stack on.
+        fs::create_dir(fsys.root.join("data")).and_then(|()| record_base(&fsys.root, selector))
+    } else {
+        copy_entry(&src.join("data"), &fsys.root.join("data")).and_then(|()| {
+            // A branch of an image-rooted filesystem is relative to the
+            // same image; the base travels with the delta it interprets.
+            match base_of(&src) {
+                Some(base) => record_base(&fsys.root, &base),
+                None => Ok(()),
+            }
+        })
+    }
+    .and_then(|()| record_parent(&fsys.root, selector));
     if let Err(e) = seed {
         let _ = fs::remove_dir_all(&fsys.root);
         return Err(io::Error::new(
@@ -346,7 +493,7 @@ use chimera::delta::{
     Origin, is_applied, is_opaque, is_whiteout, mark_applied, origin, record_origin,
 };
 
-use crate::opts::{FsAction, FsApplyCmd, FsBranchCmd, FsDiffCmd, FsPruneCmd, FsRmCmd};
+use crate::opts::{FsAction, FsApplyCmd, FsBranchCmd, FsDiffCmd, FsPruneCmd, FsPullCmd, FsRmCmd};
 
 /// Entry point for `chimera fs <action>`.
 pub fn command(action: FsAction) -> std::process::ExitCode {
@@ -355,6 +502,7 @@ pub fn command(action: FsAction) -> std::process::ExitCode {
         FsAction::Diff(FsDiffCmd { filesystem }) => diff(&filesystem),
         FsAction::Apply(FsApplyCmd { filesystem }) => apply(&filesystem),
         FsAction::Branch(FsBranchCmd { filesystem }) => branch_cmd(&filesystem),
+        FsAction::Pull(FsPullCmd { image }) => pull_cmd(&image),
         FsAction::Rm(FsRmCmd { filesystems }) => rm(&filesystems),
         FsAction::Prune(FsPruneCmd { force }) => prune(force),
     };
@@ -445,9 +593,16 @@ fn row(id: &str, root: &Path) -> String {
         .parse::<u64>()
         .map(|created| human_age(now_secs().saturating_sub(created)))
         .unwrap_or_default();
-    let parent = match field("parent =") {
-        p if p.is_empty() => "host".to_string(),
-        p => p,
+    // An image filesystem is a root: it descends from nothing, and `-` is
+    // that fact in the FROM column. An ordinary filesystem with no recorded
+    // parent branched the live host, which the absence of the record encodes.
+    let parent = if !field("image =").is_empty() {
+        "-".to_string()
+    } else {
+        match field("parent =") {
+            p if p.is_empty() => "host".to_string(),
+            p => p,
+        }
     };
     format!(
         "{id:<10} {parent:<10} {age:>5} {:>8}  {}",
@@ -519,14 +674,14 @@ impl Kind {
 /// children. Directories themselves are listed only when opaque (they
 /// replace the lower directory wholesale); an ordinary upper directory is
 /// just the scaffolding under its children.
-fn changes(root: &Path) -> io::Result<Vec<Change>> {
+fn changes(root: &Path, lower: &Path) -> io::Result<Vec<Change>> {
     let data = root.join("data");
     let mut out = Vec::new();
-    walk(&data, Path::new("/"), &mut out)?;
+    walk(&data, Path::new("/"), lower, &mut out)?;
     Ok(out)
 }
 
-fn walk(upper_dir: &Path, guest_dir: &Path, out: &mut Vec<Change>) -> io::Result<()> {
+fn walk(upper_dir: &Path, guest_dir: &Path, lower: &Path, out: &mut Vec<Change>) -> io::Result<()> {
     let mut entries: Vec<_> = fs::read_dir(upper_dir)?.filter_map(Result::ok).collect();
     entries.sort_by_key(|e| e.file_name());
     for entry in entries {
@@ -544,16 +699,16 @@ fn walk(upper_dir: &Path, guest_dir: &Path, out: &mut Vec<Change>) -> io::Result
         if md.is_dir() {
             if is_opaque(&upper).map_err(errno_to_io)? {
                 out.push(Change {
-                    kind: kind_against_host(&guest),
+                    kind: kind_against_lower(lower, &guest),
                     path: guest.clone(),
                     upper: upper.clone(),
                 });
             }
-            walk(&upper, &guest, out)?;
+            walk(&upper, &guest, lower, out)?;
             continue;
         }
         out.push(Change {
-            kind: kind_against_host(&guest),
+            kind: kind_against_lower(lower, &guest),
             path: guest,
             upper,
         });
@@ -561,12 +716,26 @@ fn walk(upper_dir: &Path, guest_dir: &Path, out: &mut Vec<Change>) -> io::Result
     Ok(())
 }
 
-/// Added or Modified, judged against the live host.
-fn kind_against_host(guest: &Path) -> Kind {
-    if fs::symlink_metadata(guest).is_ok() {
+/// Added or Modified, judged against the tree the change-set is relative to:
+/// the live host (`lower` is `/`, and the guest path is the host path), or an
+/// image filesystem's tree.
+fn kind_against_lower(lower: &Path, guest: &Path) -> Kind {
+    let target = lower.join(guest.strip_prefix("/").unwrap_or(guest));
+    if fs::symlink_metadata(target).is_ok() {
         Kind::Modified
     } else {
         Kind::Added
+    }
+}
+
+/// The tree `root`'s change-set is relative to: `/` for the live host, an
+/// image filesystem's `data/` when a `base` record names one.
+fn lower_of(root: &Path) -> io::Result<PathBuf> {
+    match base_of(root) {
+        Some(base) => Ok(resolve(&base)
+            .map_err(|e| io::Error::new(e.kind(), format!("base image filesystem {base}: {e}")))?
+            .join("data")),
+        None => Ok(PathBuf::from("/")),
     }
 }
 
@@ -576,9 +745,24 @@ fn errno_to_io(e: chimera::Errno) -> io::Error {
 
 fn diff(selector: &str) -> io::Result<()> {
     let root = resolve(selector)?;
-    for change in changes(&root)? {
+    if let Some(image) = image_of(&root) {
+        return Err(io::Error::other(format!(
+            "{image} is an image — a base tree, not a change-set"
+        )));
+    }
+    let lower = lower_of(&root)?;
+    for change in changes(&root, &lower)? {
         println!("{} {}", change.kind.letter(), change.path.display());
     }
+    Ok(())
+}
+
+/// `chimera fs pull`: the id on stdout is the whole interface, mirroring
+/// `fs branch` — `chimera run --from $(chimera fs pull docker:debian:13-slim)`
+/// is pinned to the digest that pull resolved.
+fn pull_cmd(image: &str) -> io::Result<()> {
+    let id = crate::docker::pull(image)?;
+    println!("{id}");
     Ok(())
 }
 
@@ -611,17 +795,44 @@ fn disposal_guard(root: &Path) -> io::Result<Option<OwnedFd>> {
 }
 
 fn rm(selectors: &[String]) -> io::Result<()> {
-    for selector in selectors {
-        let root = resolve(selector)?;
-        let _guard = disposal_guard(&root).map_err(|_| {
+    let victims: Vec<PathBuf> = selectors
+        .iter()
+        .map(|s| resolve(s))
+        .collect::<io::Result<_>>()?;
+    for (selector, root) in selectors.iter().zip(&victims) {
+        // A branch references its base image rather than copying it, so an
+        // image with surviving dependents must stay. A dependent going in
+        // the same command is not a survivor.
+        if image_of(root).is_some()
+            && let Some(dependent) = dependent_of(selector, root, &victims)
+        {
+            return Err(io::Error::other(format!(
+                "filesystem {dependent} branches image {selector}; remove it first"
+            )));
+        }
+        let _guard = disposal_guard(root).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::WouldBlock,
                 format!("filesystem {selector} is in use"),
             )
         })?;
-        fs::remove_dir_all(&root)?;
+        fs::remove_dir_all(root)?;
     }
     Ok(())
+}
+
+/// A kept filesystem whose `base` names this image, excluding those going in
+/// the same removal. The base record holds whatever selector the branch was
+/// created from, so both the image's id and the spelled selector count.
+fn dependent_of(selector: &str, root: &Path, victims: &[PathBuf]) -> Option<String> {
+    let id = root.file_name()?.to_string_lossy().into_owned();
+    let entries = fs::read_dir(filesystems_dir()).ok()?;
+    entries
+        .filter_map(Result::ok)
+        .filter(|e| !victims.contains(&e.path()))
+        .filter(|e| matches!(base_of(&e.path()), Some(base) if base == id || base == selector))
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .next()
 }
 
 /// Remove every filesystem under the state directory that no live session
@@ -684,8 +895,21 @@ fn prune(force: bool) -> io::Result<()> {
 /// command report failure.
 fn apply(selector: &str) -> io::Result<()> {
     let root = resolve(selector)?;
+    // Apply's one meaning is copying changes onto the live host. An image is
+    // not a change-set at all, and an image-rooted change-set is relative to
+    // the image's tree — pasting either onto the host would be nonsense.
+    if let Some(image) = image_of(&root) {
+        return Err(io::Error::other(format!(
+            "{image} is an image — a base tree, not changes to apply"
+        )));
+    }
+    if let Some(base) = base_of(&root) {
+        return Err(io::Error::other(format!(
+            "filesystem {selector} branches image {base}; its changes are relative to the image, not the host"
+        )));
+    }
     let mut conflicts = 0u32;
-    for change in changes(&root)? {
+    for change in changes(&root, Path::new("/"))? {
         match apply_change(&change) {
             Ok(()) => println!("{} {}", change.kind.letter(), change.path.display()),
             Err(ApplyError::Conflict) => {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,10 +1,11 @@
+mod docker;
 mod fs;
 mod opts;
 mod prompt;
 
 use std::{
     env,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     io,
     os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
@@ -46,6 +47,11 @@ fn version() -> ExitCode {
     ExitCode::SUCCESS
 }
 
+/// What a run assembles before the sandbox starts: the merged root the guest
+/// sees, the filesystem receiving its changes (`None` under `--unsafe`), and
+/// the held base image tree when that filesystem branched an image.
+type Session = (Arc<dyn Vfs>, Option<fs::Filesystem>, Option<fs::Base>);
+
 fn run(mut cmd: RunCmd) -> ExitCode {
     // Only a shell Chimera starts on its own gets a badged prompt; a program
     // the user named runs exactly as typed.
@@ -61,14 +67,14 @@ fn run(mut cmd: RunCmd) -> ExitCode {
     // at all. The host changes only through `fs apply`. The host root must
     // exist, so its construction cannot fail.
     let host = Arc::new(HostFs::new("/").expect("host root / is a directory"));
-    let (root, fsys): (Arc<dyn Vfs>, Option<fs::Filesystem>) = if cmd.unsafe_ {
+    let (root, fsys, base): Session = if cmd.unsafe_ {
         // The explicit flags contradict --unsafe; the ambient environment
         // variable is merely inert, like any other env a script exports.
         if cmd.from.is_some() || cmd.in_.is_some() || cmd.rm {
             eprintln!("chimera: --unsafe runs without a filesystem");
             return ExitCode::FAILURE;
         }
-        (host, None)
+        (host, None, None)
     } else {
         if cmd.from.is_some() && cmd.in_.is_some() {
             eprintln!("chimera: a run either branches with --from or resumes with --in, not both");
@@ -94,10 +100,22 @@ fn run(mut cmd: RunCmd) -> ExitCode {
         if let Some(sel) = &selector
             && let Some(scheme) = fs::scheme(sel)
         {
-            eprintln!(
-                "chimera: unknown filesystem scheme \"{scheme}:\" (a path whose first component contains a colon needs a leading ./)",
-            );
-            return ExitCode::FAILURE;
+            if scheme != "docker" {
+                eprintln!(
+                    "chimera: unknown filesystem scheme \"{scheme}:\" (a path whose first component contains a colon needs a leading ./)",
+                );
+                return ExitCode::FAILURE;
+            }
+            // An image can only ever be a branch point: resuming one would
+            // falsify the provenance every branch of it depends on.
+            if resume.is_some() {
+                eprintln!(
+                    "chimera: {} is an image and immutable; branch it with --from{}",
+                    Path::new(sel).display(),
+                    if from_env { " (CHIMERA_FS)" } else { "" },
+                );
+                return ExitCode::FAILURE;
+            }
         }
         // A locator names a filesystem; the verb decides what happens to
         // it: `--from` branches, leaving the source exactly as it was, and
@@ -118,6 +136,18 @@ fn run(mut cmd: RunCmd) -> ExitCode {
             Some(sel) => fs::resume(&sel.to_string_lossy()),
             None => match &cmd.from {
                 Some(sel) if sel == "host" => fs::create(&describe(&cmd)),
+                // A docker: image resolves to a kept image filesystem —
+                // pulled now if this is its first use — and the run branches
+                // that, exactly as if its id had been named.
+                Some(sel) if fs::scheme(OsStr::new(sel)).as_deref() == Some("docker") => {
+                    match docker::pull(sel) {
+                        Ok(id) => fs::branch(&id, &describe(&cmd)),
+                        Err(err) => {
+                            eprintln!("chimera: cannot pull {sel}: {err}");
+                            return ExitCode::FAILURE;
+                        }
+                    }
+                }
                 Some(sel) => fs::branch(sel, &describe(&cmd)),
                 None => fs::create(&describe(&cmd)),
             },
@@ -136,8 +166,33 @@ fn run(mut cmd: RunCmd) -> ExitCode {
         if from_env && let Some(sel) = &resume {
             eprintln!("chimera: --in {} (CHIMERA_FS)", Path::new(sel).display());
         }
-        match OverlayFs::new(host, &fsys.root) {
-            Ok(overlay) => (Arc::new(overlay), Some(fsys)),
+        // The change-set's lower layer: the live host, or — for a filesystem
+        // that branched an image — the image's complete tree, held for the
+        // session so removal waits for the run.
+        let base = match fs::base_of(&fsys.root).map(|sel| fs::open_base(&sel)) {
+            None => None,
+            Some(Ok(base)) => Some(base),
+            Some(Err(err)) => {
+                eprintln!("chimera: {err}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let lower: Arc<dyn Vfs> = match &base {
+            None => host,
+            Some(b) => match HostFs::new(&b.data) {
+                Ok(image) => Arc::new(image),
+                Err(err) => {
+                    eprintln!(
+                        "chimera: cannot open image tree {}: {}",
+                        b.data.display(),
+                        io::Error::from_raw_os_error(err.raw()),
+                    );
+                    return ExitCode::FAILURE;
+                }
+            },
+        };
+        match OverlayFs::new(lower, &fsys.root) {
+            Ok(overlay) => (Arc::new(overlay), Some(fsys), base),
             Err(err) => {
                 let err = io::Error::from_raw_os_error(err.raw());
                 let hint = if err.kind() == io::ErrorKind::Unsupported {
@@ -153,8 +208,11 @@ fn run(mut cmd: RunCmd) -> ExitCode {
             }
         }
     };
-    // Held for the whole run: dropping the prompt removes the rc file.
-    let _prompt = if implicit_shell && !cmd.no_prompt {
+    // Held for the whole run: dropping the prompt removes the rc file. An
+    // image-rooted session gets no badge yet: the rc file lives on the host,
+    // and the guest's namespace bottoms out in the image tree, where the
+    // file does not exist.
+    let _prompt = if implicit_shell && !cmd.no_prompt && base.is_none() {
         match prompt::Prompt::new(fsys.as_ref()) {
             Ok(prompt) => {
                 cmd.argv.push("--rcfile".into());
@@ -170,6 +228,13 @@ fn run(mut cmd: RunCmd) -> ExitCode {
     } else {
         None
     };
+    // Under an image root the host's cwd names nothing in the guest's tree;
+    // the session starts at the image's root instead.
+    let guest_cwd = if base.is_some() {
+        PathBuf::from("/")
+    } else {
+        env::current_dir().unwrap_or_else(|_| PathBuf::from("/"))
+    };
     let (program, args) = cmd.argv.split_first().expect("argv names a program");
     let program = Path::new(program);
     // Resolve the initial executable through the same merged view the
@@ -177,7 +242,7 @@ fn run(mut cmd: RunCmd) -> ExitCode {
     // replaced or deleted the program, its script, or its interpreter, and
     // the session must load the bytes the guest observes, not the lower
     // host's.
-    let program = match resolve_program(root.as_ref(), program, args) {
+    let program = match resolve_program(root.as_ref(), &guest_cwd, program, args) {
         Ok(program) => program,
         Err(err) => {
             eprintln!("chimera: {err}");
@@ -197,11 +262,27 @@ fn run(mut cmd: RunCmd) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    // The guest knows the program by its merged-view path; the host_exec
+    // backing file is the loader's business, not argv[0]'s.
+    sandbox.arg0(&program.exec);
     if let Some(mib) = cmd.code_cache_size {
         sandbox.code_cache_size(mib.saturating_mul(1024 * 1024));
     }
 
-    let personality = Personality::new(Namespace::with_root(root, MountFlags::NONE));
+    let mut ns = Namespace::with_root(root, MountFlags::NONE);
+    if base.is_some() {
+        // The kernel's virtual trees and the device nodes are interfaces to
+        // the running host, not content an image tarball could carry; the
+        // host serves them over the image tree. A host without one of them
+        // has nothing to mount, which is also what the guest should see.
+        for point in ["/proc", "/sys", "/dev"] {
+            if let Ok(host_tree) = HostFs::new(point) {
+                ns.mount(point, Arc::new(host_tree), MountFlags::NONE);
+            }
+        }
+    }
+    let personality = Personality::new(ns);
+    personality.set_cwd(&guest_cwd);
     personality.set_exe(&program.exec);
     sandbox.system_calls(personality);
 
@@ -232,8 +313,13 @@ struct Program {
     args: Vec<OsString>,
 }
 
-fn resolve_program(root: &dyn Vfs, program: &Path, args: &[String]) -> Result<Program, io::Error> {
-    let (exec, host_exec) = resolve_path(root, program)?;
+fn resolve_program(
+    root: &dyn Vfs,
+    cwd: &Path,
+    program: &Path,
+    args: &[String],
+) -> Result<Program, io::Error> {
+    let (exec, host_exec) = resolve_path(root, cwd, program)?;
     if let Some((interpreter, interpreter_args)) = read_shebang(&host_exec)? {
         let mut exec_args = interpreter_args;
         // Run shebang scripts through their interpreter so the runtime still
@@ -241,7 +327,7 @@ fn resolve_program(root: &dyn Vfs, program: &Path, args: &[String]) -> Result<Pr
         // script by its guest-visible name.
         exec_args.push(exec.into_os_string());
         exec_args.extend(args.iter().map(OsString::from));
-        let (exec, host_exec) = resolve_path(root, &interpreter)?;
+        let (exec, host_exec) = resolve_path(root, cwd, &interpreter)?;
         return Ok(Program {
             exec,
             host_exec,
@@ -260,9 +346,13 @@ fn resolve_program(root: &dyn Vfs, program: &Path, args: &[String]) -> Result<Pr
 /// serving it. A bare name walks `PATH` with each candidate's existence
 /// judged in the merged view, so a filesystem whiteout hides a candidate
 /// instead of letting the lower host file shadow through.
-fn resolve_path(root: &dyn Vfs, program: &Path) -> Result<(PathBuf, PathBuf), io::Error> {
+fn resolve_path(
+    root: &dyn Vfs,
+    cwd: &Path,
+    program: &Path,
+) -> Result<(PathBuf, PathBuf), io::Error> {
     if program.is_absolute() || program.components().count() > 1 {
-        let exec = absolutize(program)?;
+        let exec = absolutize(cwd, program);
         let host = root.host_path(&exec).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
@@ -274,7 +364,7 @@ fn resolve_path(root: &dyn Vfs, program: &Path) -> Result<(PathBuf, PathBuf), io
 
     let path = env::var_os("PATH").unwrap_or_default();
     for dir in env::split_paths(&path) {
-        let candidate = absolutize(&dir.join(program))?;
+        let candidate = absolutize(cwd, &dir.join(program));
         if let Some(host) = root.host_path(&candidate)
             && host.is_file()
         {
@@ -288,12 +378,12 @@ fn resolve_path(root: &dyn Vfs, program: &Path) -> Result<(PathBuf, PathBuf), io
     ))
 }
 
-/// The lexically absolute form of `path`, anchored at the current directory:
-/// the merged view is indexed by absolute guest paths.
-fn absolutize(path: &Path) -> Result<PathBuf, io::Error> {
+/// The lexically absolute form of `path`, anchored at the guest's initial
+/// working directory: the merged view is indexed by absolute guest paths.
+fn absolutize(cwd: &Path, path: &Path) -> PathBuf {
     use std::path::Component;
 
-    let mut out = env::current_dir()?;
+    let mut out = cwd.to_path_buf();
     for c in path.components() {
         match c {
             Component::RootDir => out = PathBuf::from("/"),
@@ -304,7 +394,7 @@ fn absolutize(path: &Path) -> Result<PathBuf, io::Error> {
             Component::Normal(n) => out.push(n),
         }
     }
-    Ok(out)
+    out
 }
 
 fn read_shebang(path: &Path) -> Result<Option<(PathBuf, Vec<OsString>)>, io::Error> {

--- a/cli/opts.rs
+++ b/cli/opts.rs
@@ -34,6 +34,7 @@ pub enum FsAction {
     Diff(FsDiffCmd),
     Apply(FsApplyCmd),
     Branch(FsBranchCmd),
+    Pull(FsPullCmd),
     Rm(FsRmCmd),
     Prune(FsPruneCmd),
 }
@@ -74,6 +75,18 @@ pub struct FsBranchCmd {
     pub filesystem: String,
 }
 
+/// Fetch a container image and keep it as an image filesystem: a complete
+/// base tree with no parent, immutable, made to be branched with --from.
+/// Prints the filesystem's id; an image already kept prints its existing id
+/// without touching the network.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "pull")]
+pub struct FsPullCmd {
+    /// image locator, e.g. docker:debian:13-slim
+    #[argh(positional)]
+    pub image: String,
+}
+
 /// Remove filesystems.
 #[derive(FromArgs)]
 #[argh(subcommand, name = "rm")]
@@ -101,8 +114,9 @@ pub struct RunCmd {
     pub code_cache_size: Option<usize>,
 
     /// the branch point: `host` for the live host (the default), a kept
-    /// filesystem's id, or a path to a change-set directory — the run stacks
-    /// a fresh change-set on it and the source stays untouched
+    /// filesystem's id, a path to a change-set directory, or a container
+    /// image like `docker:debian:13-slim` — the run stacks a fresh
+    /// change-set on it and the source stays untouched
     #[argh(option, short = 'f')]
     pub from: Option<String>,
 

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -56,6 +56,7 @@ pub fn mpk_enabled() -> bool {
 /// A sandboxed guest program, configured but not yet running.
 pub struct Sandbox {
     program: PathBuf,
+    arg0: Option<OsString>,
     args: Vec<OsString>,
     envs: Option<Vec<(OsString, OsString)>>,
     handler: Box<dyn SystemCalls>,
@@ -69,11 +70,21 @@ impl Sandbox {
         sys::mmap::init()?;
         Ok(Self {
             program: program.as_ref().to_path_buf(),
+            arg0: None,
             args: Vec::new(),
             envs: None,
             handler: Box::new(Passthrough),
             code_cache_size: DEFAULT_CODE_CACHE_SIZE,
         })
+    }
+
+    /// Set the guest's `argv[0]`, when the name the guest should see differs
+    /// from the file the loader reads — an embedder whose namespace serves
+    /// the program from a backing file elsewhere passes the guest-visible
+    /// path here. Defaults to the program path.
+    pub fn arg0(&mut self, arg0: impl AsRef<OsStr>) -> &mut Self {
+        self.arg0 = Some(arg0.as_ref().to_os_string());
+        self
     }
 
     /// Append a single argument to the guest's argv.
@@ -138,6 +149,7 @@ impl Sandbox {
         let handler = std::mem::replace(&mut self.handler, Box::new(Passthrough));
         let code = sys::exec::execv(
             &self.program,
+            self.arg0.as_deref(),
             &self.args,
             self.envs.as_deref(),
             handler,

--- a/runtime/sys/linux/exec.rs
+++ b/runtime/sys/linux/exec.rs
@@ -33,16 +33,18 @@ const AT_EMPTY_PATH: i32 = 0x1000;
 
 pub fn execv(
     program: &Path,
+    arg0: Option<&OsStr>,
     args: &[OsString],
     envs: Option<&[(OsString, OsString)]>,
     handler: Box<dyn SystemCalls>,
     code_cache_size: usize,
 ) -> Result<i32, Error> {
     // The first image's argv and envp come from the embedder: argv[0] is the
-    // program path, then the supplied args; the environment is the explicit set
-    // if one was given, otherwise the host's.
+    // guest-visible program name (the program path unless overridden), then
+    // the supplied args; the environment is the explicit set if one was
+    // given, otherwise the host's.
     let mut argv: Vec<Vec<u8>> = Vec::with_capacity(args.len() + 1);
-    argv.push(program.as_os_str().as_bytes().to_vec());
+    argv.push(arg0.unwrap_or(program.as_os_str()).as_bytes().to_vec());
     for a in args {
         argv.push(a.as_bytes().to_vec());
     }
@@ -54,15 +56,17 @@ pub fn execv(
     let main = load_elf(program)?;
     let (rip, interp_base, interp) = match &main.interp {
         Some(interp_path) => {
-            let interp = load_elf(interp_path)?;
+            let interp = load_elf(&resolve_image_path(interp_path, handler.as_ref())?)?;
             (interp.entry, interp.base, Some(interp))
         }
         None => (main.entry, 0, None),
     };
+    // `AT_EXECFN` is guest-visible the same way argv[0] is; both carry the
+    // name the guest knows itself by, not the backing file the loader read.
     let (rsp, stack_start, stack_len) = build_stack(
         &argv,
         &envp,
-        program.as_os_str().as_bytes(),
+        arg0.unwrap_or(program.as_os_str()).as_bytes(),
         &main,
         interp_base,
     )?;
@@ -220,7 +224,7 @@ pub fn prepare_exec(
     let req = read_request(number, args, handler)?;
     let parsed = parse_elf(&req.path)?;
     let parsed_interp = match &parsed.interp {
-        Some(interp_path) => Some(parse_elf(interp_path)?),
+        Some(interp_path) => Some(parse_elf(&resolve_image_path(interp_path, handler)?)?),
         None => None,
     };
     Ok(PreparedExec {
@@ -228,6 +232,23 @@ pub fn prepare_exec(
         parsed,
         parsed_interp,
     })
+}
+
+/// The host file backing a guest-visible image path. `PT_INTERP` names the
+/// dynamic interpreter by its guest path, and only the handler's namespace
+/// can say which host file serves it — under an image-rooted filesystem the
+/// guest's `/lib64/ld-linux-x86-64.so.2` is the image's, not the host's, and
+/// loading the host's mixes two libcs into one process. A handler with no
+/// resolver ([`Passthrough`]) reads the path as-is.
+fn resolve_image_path(path: &Path, handler: &dyn SystemCalls) -> Result<PathBuf, Error> {
+    match handler.resolve_exec(AT_FDCWD, path.as_os_str().as_bytes(), 0) {
+        Some(Ok(host)) => Ok(host),
+        Some(Err(errno)) => Err(Error::io(
+            format!("interpreter {}", path.display()),
+            std::io::Error::from_raw_os_error(errno),
+        )),
+        None => Ok(path.to_path_buf()),
+    }
 }
 
 /// The errno a failed [`prepare_exec`] reports to the guest. `None` for

--- a/runtime/sys/linux/personality.rs
+++ b/runtime/sys/linux/personality.rs
@@ -97,6 +97,13 @@ impl Personality {
         }
     }
 
+    /// Set the guest's initial working directory, overriding the inherited
+    /// one — the embedder's choice when the host's cwd names nothing in the
+    /// guest's namespace, as under an image-rooted filesystem.
+    pub fn set_cwd(&self, path: impl Into<PathBuf>) {
+        *self.cwd.lock().unwrap() = normalize(&path.into());
+    }
+
     /// Record the guest image the sandbox launches, for `/proc/self/exe`.
     /// Canonicalized so the guest sees the absolute path the kernel would
     /// store.


### PR DESCRIPTION
Every filesystem's lower layer was the live host tree, so a guest always
saw this machine's userland; basing a sandbox on a known image — a fleet
of agents on debian:13-slim rather than on whatever the host happens to
run — had no spelling. The locator grammar reserved `<word>:...` for
exactly this, and this patch claims the first scheme.

A `docker:` locator now names a container image anywhere a branch point
is accepted. `chimera fs pull docker:debian:13-slim` fetches the image
over the registry distribution protocol (anonymous Bearer-token flow;
public images on Docker Hub, GHCR, and any conforming registry),
verifies every manifest and blob with sha256, flattens the layer stack —
OCI whiteouts applied, every removal path confined to the stage so a
malicious layer cannot reach outside it — and keeps the result as an
image filesystem: an ordinary entry in `fs list` whose FROM column reads
`-`, because it is a complete tree descending from nothing. The id
prints on stdout, so `--from $(chimera fs pull ...)` pins the resolved
digest. `chimera run --from docker:debian:13-slim` resolves through the
same kept image, pulling only on first use, and branches it. Transport
borrows curl(1) and sha256sum(1) rather than growing a TLS stack.

An image filesystem is immutable: `--in` refuses it the way it refuses
`host`, since one resumed session would falsify the digest recorded in
its provenance for every branch stacked on it. Immutability is also what
lets a branch reference its base — a `base` file naming the image, the
one load-bearing record outside the delta tree — instead of copying 78MB
of tree per branch; in exchange, `fs rm` refuses an image that kept
filesystems still branch from, and a running session holds the base's
lock so removal waits for it. `fs diff` of an image-rooted filesystem
compares against the image's tree rather than the host, and `fs apply`
is refused outright: the changes are relative to the image, and pasting
them onto the host would be nonsense. At run time the branch's overlay
takes the image tree as its lower in place of `/`; the host still serves
`/proc`, `/sys`, and `/dev` as namespace mounts, since those are kernel
interfaces no tarball can carry, and the session starts at `/`, the only
directory the host's cwd is guaranteed to correspond to nowhere in.

Two runtime fixes fell out. PT_INTERP was loaded by its literal path, so
a Debian guest ran under the host's ld.so — Fedora's ld-linux 2.42
paired with Debian's libc 2.41 dies by SIGSEGV before main; the
interpreter now resolves through the handler's namespace like the
program itself. And argv[0] and AT_EXECFN carried the backing file's
host path (bash reported itself as `.../data/usr/bin/bash`); Sandbox
grew an `arg0` so the guest knows itself by its merged-view name.

Verified by the conformance suite (151/151), the new locator and
whiteout unit tests, and a live bring-up: debian:13-slim pulls, bash and
coreutils run against the image tree on a Fedora host, branches diff and
resume against the image, and every refusal path answers with the
message documented in the manual.
