### PR TITLE
runtime: install the initial program through the execve path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "libc",
  "log",
  "mimalloc",
- "shlex",
  "smallvec",
  "zerocopy",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,6 @@ chimera-runtime = { path = "../runtime" }
 argh = "0.1.19"
 libc = "0.2"
 mimalloc = "0.1.52"
-shlex = "1.3.0"
 
 # Used only by the vendored fuser module (cli/fuser).
 log = "0.4"

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -175,12 +175,11 @@ fn run(mut cmd: RunCmd) -> ExitCode {
     };
     let (program, args) = cmd.argv.split_first().expect("argv names a program");
     let program = Path::new(program);
-    // Resolve the initial executable through the same merged view the
-    // guest's own syscalls will see: an inherited change-set may have
-    // replaced or deleted the program, its script, or its interpreter, and
-    // the session must load the bytes the guest observes, not the lower
-    // host's.
-    let program = match resolve_program(root.as_ref(), program, args) {
+    // Resolve a bare name through `PATH` with existence judged in the same
+    // merged view the guest's own syscalls will see, and report a missing
+    // program here, before a session starts. The runtime re-resolves the
+    // guest path — shebang splice included — when it installs the image.
+    let program = match resolve_program(root.as_ref(), program) {
         Ok(program) => program,
         Err(err) => {
             eprintln!("chimera: {err}");
@@ -190,7 +189,7 @@ fn run(mut cmd: RunCmd) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let mut sandbox = match Sandbox::new(&program.host_exec) {
+    let mut sandbox = match Sandbox::new(&program) {
         Ok(sandbox) => sandbox,
         Err(err) => {
             eprintln!("chimera: {err}");
@@ -205,10 +204,9 @@ fn run(mut cmd: RunCmd) -> ExitCode {
     }
 
     let personality = Personality::new(Namespace::with_root(root, MountFlags::NONE));
-    personality.set_exe(&program.exec);
     sandbox.system_calls(personality);
 
-    let result = sandbox.args(&program.args).run();
+    let result = sandbox.args(args).run();
     if let Some(fsys) = fsys {
         fsys.finish(cmd.rm);
     }
@@ -226,53 +224,20 @@ fn describe(cmd: &RunCmd) -> String {
     cmd.argv.join(" ")
 }
 
-struct Program {
-    /// The guest-visible executable path — what `/proc/self/exe` reports.
-    exec: PathBuf,
-    /// The host file serving `exec` through the merged view; where the ELF
-    /// loader actually reads.
-    host_exec: PathBuf,
-    args: Vec<OsString>,
-}
-
-fn resolve_program(root: &dyn Vfs, program: &Path, args: &[String]) -> Result<Program, io::Error> {
-    let (exec, host_exec) = resolve_path(root, program)?;
-    if let Some((interpreter, interpreter_args)) = read_shebang(&host_exec)? {
-        let mut exec_args = interpreter_args;
-        // Run shebang scripts through their interpreter so the runtime still
-        // only has to execute ELF binaries. The interpreter re-opens the
-        // script by its guest-visible name.
-        exec_args.push(exec.into_os_string());
-        exec_args.extend(args.iter().map(OsString::from));
-        let (exec, host_exec) = resolve_path(root, &interpreter)?;
-        return Ok(Program {
-            exec,
-            host_exec,
-            args: exec_args,
-        });
-    }
-
-    Ok(Program {
-        exec,
-        host_exec,
-        args: args.iter().map(OsString::from).collect(),
-    })
-}
-
-/// Resolve `program` to its guest-visible absolute path and the host file
-/// serving it. A bare name walks `PATH` with each candidate's existence
-/// judged in the merged view, so a filesystem whiteout hides a candidate
-/// instead of letting the lower host file shadow through.
-fn resolve_path(root: &dyn Vfs, program: &Path) -> Result<(PathBuf, PathBuf), io::Error> {
+/// Resolve `program` to its guest-visible absolute path. A bare name walks
+/// `PATH` with each candidate's existence judged in the merged view, so a
+/// filesystem whiteout hides a candidate instead of letting the lower host
+/// file shadow through.
+fn resolve_program(root: &dyn Vfs, program: &Path) -> Result<PathBuf, io::Error> {
     if program.is_absolute() || program.components().count() > 1 {
         let exec = absolutize(program)?;
-        let host = root.host_path(&exec).ok_or_else(|| {
+        root.host_path(&exec).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("program {:?}: no such file or directory", exec.display()),
             )
         })?;
-        return Ok((exec, host));
+        return Ok(exec);
     }
 
     let path = env::var_os("PATH").unwrap_or_default();
@@ -281,7 +246,7 @@ fn resolve_path(root: &dyn Vfs, program: &Path) -> Result<(PathBuf, PathBuf), io
         if let Some(host) = root.host_path(&candidate)
             && host.is_file()
         {
-            return Ok((candidate, host));
+            return Ok(candidate);
         }
     }
 
@@ -308,37 +273,4 @@ fn absolutize(path: &Path) -> Result<PathBuf, io::Error> {
         }
     }
     Ok(out)
-}
-
-fn read_shebang(path: &Path) -> Result<Option<(PathBuf, Vec<OsString>)>, io::Error> {
-    let bytes = std::fs::read(path)?;
-    if !bytes.starts_with(b"#!") {
-        return Ok(None);
-    }
-
-    let line_end = bytes
-        .iter()
-        .position(|&b| b == b'\n')
-        .unwrap_or(bytes.len());
-    let line = bytes[2..line_end]
-        .strip_suffix(b"\r")
-        .unwrap_or(&bytes[2..line_end]);
-    let line = String::from_utf8_lossy(line);
-    let words = shlex::split(&line).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("invalid shebang in {}", path.display()),
-        )
-    })?;
-    let Some((interpreter, args)) = words.split_first() else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("empty shebang in {}", path.display()),
-        ));
-    };
-
-    Ok(Some((
-        PathBuf::from(interpreter),
-        args.iter().map(OsString::from).collect(),
-    )))
 }

--- a/runtime/lib.rs
+++ b/runtime/lib.rs
@@ -63,7 +63,11 @@ pub struct Sandbox {
 }
 
 impl Sandbox {
-    /// Create a new sandbox for the given program.
+    /// Create a new sandbox for the given program. The path is the
+    /// guest-visible name: [`Sandbox::run`] resolves and installs it exactly
+    /// like a guest `execve` target — through the handler's namespace, `#!`
+    /// scripts spliced onto their interpreter — so the initial program comes
+    /// from the same view the guest's own execs use.
     pub fn new(program: impl AsRef<Path>) -> Result<Self, Error> {
         arch::init()?;
         sys::mmap::init()?;

--- a/runtime/sys/linux/exec.rs
+++ b/runtime/sys/linux/exec.rs
@@ -40,7 +40,10 @@ pub fn execv(
 ) -> Result<i32, Error> {
     // The first image's argv and envp come from the embedder: argv[0] is the
     // program path, then the supplied args; the environment is the explicit set
-    // if one was given, otherwise the host's.
+    // if one was given, otherwise the host's. The program path is the
+    // guest-visible name, resolved and installed exactly like a guest `execve`
+    // target — handler namespace, shebang splice, and `on_execve` report — so
+    // the initial image comes from the same view the guest's own execs use.
     let mut argv: Vec<Vec<u8>> = Vec::with_capacity(args.len() + 1);
     argv.push(program.as_os_str().as_bytes().to_vec());
     for a in args {
@@ -50,8 +53,17 @@ pub fn execv(
         Some(over) => over.iter().map(|(k, v)| env_pair(k, v)).collect(),
         None => std::env::vars_os().map(|(k, v)| env_pair(&k, &v)).collect(),
     };
+    let raw = program.as_os_str().as_bytes().to_vec();
+    let path = resolve_exec_path(AT_FDCWD, &raw, 0, &*handler)?;
+    let mut req = ExecRequest {
+        path,
+        raw,
+        argv,
+        envp,
+    };
+    splice_shebang(&mut req, &*handler)?;
 
-    let main = load_elf(program)?;
+    let main = load_elf(&req.path)?;
     let (rip, interp_base, interp) = match &main.interp {
         Some(interp_path) => {
             let interp = load_elf(interp_path)?;
@@ -59,13 +71,9 @@ pub fn execv(
         }
         None => (main.entry, 0, None),
     };
-    let (rsp, stack_start, stack_len) = build_stack(
-        &argv,
-        &envp,
-        program.as_os_str().as_bytes(),
-        &main,
-        interp_base,
-    )?;
+    handler.on_execve(&req.path);
+    let (rsp, stack_start, stack_len) =
+        build_stack(&req.argv, &req.envp, &req.raw, &main, interp_base)?;
 
     // The process's shared state: the address space, code cache, and the
     // embedder's syscall handler. The first thread is created against it; future
@@ -218,41 +226,7 @@ pub fn prepare_exec(
     handler: &dyn SystemCalls,
 ) -> Result<PreparedExec, Error> {
     let mut req = read_request(number, args, handler)?;
-    // A `#!` script executes through its interpreter line, spliced the way
-    // the kernel's script loader does it: argv becomes the interpreter, its
-    // optional argument, the script's pathname as the caller wrote it, then
-    // the caller's argv past argv[0]. The interpreter may itself be a
-    // script, to the kernel's nesting depth; one level deeper falls through
-    // to `parse_elf`, whose failure reports `ENOEXEC`.
-    let mut script = if req.raw.is_empty() {
-        req.path.as_os_str().as_bytes().to_vec()
-    } else {
-        req.raw.clone()
-    };
-    for _ in 0..4 {
-        let Some((interp, optarg)) = shebang_line(&req.path)? else {
-            break;
-        };
-        let mut argv: Vec<Vec<u8>> = Vec::with_capacity(req.argv.len() + 2);
-        argv.push(interp.clone());
-        if let Some(arg) = optarg {
-            argv.push(arg);
-        }
-        argv.push(script);
-        argv.extend(req.argv.iter().skip(1).cloned());
-        req.argv = argv;
-        req.path = match handler.resolve_exec(AT_FDCWD, &interp, 0) {
-            Some(Ok(path)) => path,
-            Some(Err(errno)) => {
-                return Err(Error::io(
-                    "execve",
-                    std::io::Error::from_raw_os_error(errno),
-                ));
-            }
-            None => resolve_at(AT_FDCWD, &interp, 0, handler),
-        };
-        script = interp;
-    }
+    splice_shebang(&mut req, handler)?;
     let parsed = parse_elf(&req.path)?;
     let parsed_interp = match &parsed.interp {
         Some(interp_path) => Some(parse_elf(interp_path)?),
@@ -273,6 +247,57 @@ pub fn exec_errno(err: &Error) -> Option<i32> {
         Error::BadBinary(_) | Error::Link(_) | Error::Unsupported(_) => Some(libc::ENOEXEC),
         Error::BadAccess(_) => Some(libc::EFAULT),
         Error::CodeCacheExhausted | Error::Translate(_) => None,
+    }
+}
+
+/// Execute a `#!` script through its interpreter line, spliced the way the
+/// kernel's script loader does it: argv becomes the interpreter, its
+/// optional argument, the script's pathname as the caller wrote it, then
+/// the caller's argv past argv[0], and the request's path becomes the
+/// interpreter's, resolved through the handler's namespace. The interpreter
+/// may itself be a script, to the kernel's nesting depth; one level deeper
+/// falls through to `parse_elf`, whose failure reports `ENOEXEC`. A request
+/// naming a plain ELF passes through untouched.
+fn splice_shebang(req: &mut ExecRequest, handler: &dyn SystemCalls) -> Result<(), Error> {
+    let mut script = if req.raw.is_empty() {
+        req.path.as_os_str().as_bytes().to_vec()
+    } else {
+        req.raw.clone()
+    };
+    for _ in 0..4 {
+        let Some((interp, optarg)) = shebang_line(&req.path)? else {
+            break;
+        };
+        let mut argv: Vec<Vec<u8>> = Vec::with_capacity(req.argv.len() + 2);
+        argv.push(interp.clone());
+        if let Some(arg) = optarg {
+            argv.push(arg);
+        }
+        argv.push(script);
+        argv.extend(req.argv.iter().skip(1).cloned());
+        req.argv = argv;
+        req.path = resolve_exec_path(AT_FDCWD, &interp, 0, handler)?;
+        script = interp;
+    }
+    Ok(())
+}
+
+/// Resolve an exec target to the host path the ELF loader reads: the
+/// handler's namespace when it claims the resolution, the runtime's default
+/// rules (see [`resolve_at`]) when it defers.
+fn resolve_exec_path(
+    dirfd: i32,
+    raw: &[u8],
+    flags: i32,
+    handler: &dyn SystemCalls,
+) -> Result<PathBuf, Error> {
+    match handler.resolve_exec(dirfd, raw, flags) {
+        Some(Ok(path)) => Ok(path),
+        Some(Err(errno)) => Err(Error::io(
+            "execve",
+            std::io::Error::from_raw_os_error(errno),
+        )),
+        None => Ok(resolve_at(dirfd, raw, flags, handler)),
     }
 }
 
@@ -400,16 +425,7 @@ fn read_request(
         (AT_FDCWD, args[0], 0, args[1], args[2])
     };
     let raw = read_guest_cstr(rawptr, libc::PATH_MAX as usize, libc::ENAMETOOLONG)?;
-    let path = match handler.resolve_exec(dirfd, &raw, flags) {
-        Some(Ok(path)) => path,
-        Some(Err(errno)) => {
-            return Err(Error::io(
-                "execve",
-                std::io::Error::from_raw_os_error(errno),
-            ));
-        }
-        None => resolve_at(dirfd, &raw, flags, handler),
-    };
+    let path = resolve_exec_path(dirfd, &raw, flags, handler)?;
     Ok(ExecRequest {
         path,
         raw,

--- a/runtime/sys/linux/personality.rs
+++ b/runtime/sys/linux/personality.rs
@@ -78,9 +78,8 @@ pub struct Personality {
     /// The guest's executed image — what `/proc/self/exe` names. Chimera
     /// emulates `execve` in place, so the kernel's own link points at the
     /// runtime binary; leaking that gives a self-respawning guest (Bun's
-    /// `execPath`) the runtime to exec instead of itself. Seeded by the
-    /// embedder ([`Personality::set_exe`]), updated on every committed exec
-    /// ([`SystemCalls::on_execve`]).
+    /// `execPath`) the runtime to exec instead of itself. Recorded at every
+    /// image install ([`SystemCalls::on_execve`]), the initial one included.
     exe: Mutex<Option<PathBuf>>,
 }
 
@@ -95,15 +94,6 @@ impl Personality {
             cwd: Mutex::new(normalize(&cwd)),
             exe: Mutex::new(None),
         }
-    }
-
-    /// Record the guest image the sandbox launches, for `/proc/self/exe`.
-    /// Canonicalized so the guest sees the absolute path the kernel would
-    /// store.
-    pub fn set_exe(&self, path: impl Into<PathBuf>) {
-        let path = path.into();
-        let path = std::fs::canonicalize(&path).unwrap_or(path);
-        *self.exe.lock().unwrap() = Some(path);
     }
 }
 
@@ -493,8 +483,11 @@ impl SystemCalls for Personality {
     }
 
     fn on_execve(&self, path: &Path) {
-        // The link target of /proc/self/exe follows the exec.
-        *self.exe.lock().unwrap() = Some(path.to_path_buf());
+        // The link target of /proc/self/exe follows the exec. Canonicalized
+        // so the guest sees the absolute, symlink-resolved path the kernel
+        // would store.
+        let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        *self.exe.lock().unwrap() = Some(path);
         // POSIX exec semantics for the table: close-on-exec entries go, the
         // rest survive into the new image with their numbers intact. Closing
         // through `FdTable::close` releases each reserved kernel number, so

--- a/runtime/syscall.rs
+++ b/runtime/syscall.rs
@@ -135,9 +135,12 @@ pub trait SystemCalls: Send + Sync {
         None
     }
 
-    /// The guest committed an `execve`: drop whatever close-on-exec state the
-    /// handler virtualizes, before the runtime's own sweep applies host-side
-    /// `FD_CLOEXEC` (see `close_cloexec_fds` in `crate::sys::linux::exec`). A
+    /// An image install committed — a guest `execve`, or the initial program
+    /// a [`Sandbox`](crate::Sandbox) run loads: drop whatever close-on-exec
+    /// state the handler virtualizes, before the runtime's own sweep applies
+    /// host-side `FD_CLOEXEC` (see `close_cloexec_fds` in
+    /// `crate::sys::linux::exec`; the initial install has no sweep, since the
+    /// runtime's own inherited descriptors are not the guest's to lose). A
     /// handler that owns a descriptor table closes its close-on-exec entries
     /// here — their close-on-exec flag lives in the table, not on a host fd,
     /// so the runtime's sweep cannot see it. The default does nothing, since


### PR DESCRIPTION
Chimera now has two shebang implementations: the runtime's kernel-faithful splice for guest `execve` (#79), and the CLI's older copy for the initial program. The CLI copy disagrees with the kernel in real ways — shlex quote-aware word-splitting where the kernel passes everything after the interpreter as a single argument, no 256-byte `BINPRM_BUF_SIZE` cap, and a stripped carriage return — so the same script could parse differently depending on whether it started the session or was exec'd from inside it. And because `Sandbox::run` fed the program straight to the ELF loader, no embedder other than the CLI could run a script at all.

This PR routes the initial program through the same machinery a guest `execve` uses, and deletes the CLI copy.

## Changes

- **`Sandbox::new` now takes the guest-visible pathname.** `run` resolves it through the handler's namespace (`SystemCalls::resolve_exec`), applies the shared shebang splice, and reports the install via `SystemCalls::on_execve` — the same sequence a guest exec goes through.
- **`SystemCalls::on_execve` now covers the initial image.** `/proc/self/exe` is seeded by the same hook that tracks it across guest execs; `Personality` canonicalizes the recorded path there, taking over what `set_exe` did, and `set_exe` is gone.
- **The CLI keeps only what belongs there**: the `PATH` walk judged against the merged view and the early missing-program report. `read_shebang`, the `shlex` dependency, and the `host_exec` plumbing are deleted.
- **Passthrough embedders inherit script support for free** — the strace and sandbox examples now run a `#!` program directly.

## Testing

- Conformance suite under Chimera and natively, 152/152 each — including `exec/execve-shebang.c`, `fs/initial-exec-attach.c` (a script as the attached session's initial executable, its interpreter resolved through the filesystem), and `process-linux/proc-self-exe.c`.
- Workspace unit tests, rustfmt, clippy.
- Manual runs: a `#!/bin/sh -u` script with caller arguments, a PATH-resolved bare name, and a missing program each behave as before.