### PR TITLE
runtime: mask the mode of a creating open to the permission bits

### DIFF
--- a/runtime/sys/linux/personality.rs
+++ b/runtime/sys/linux/personality.rs
@@ -704,12 +704,15 @@ impl Personality {
     fn open(&self, dirfd: i32, pathptr: u64, flags: i32, mode: u32) -> Result<i64, Errno> {
         // open(2) ignores `mode` unless the call creates a file (O_CREAT or
         // O_TMPFILE) — the third argument is variadic and callers routinely
-        // pass a stale value on plain reads. openat2, which HostFs resolves
-        // through, instead rejects a nonzero mode on a non-creating open
-        // with EINVAL, so apply the kernel's open(2) rule before any
-        // filesystem sees it.
+        // pass a stale value on plain reads — and even on a creating open it
+        // masks everything outside the permission bits, so the common idiom
+        // open(dst, O_CREAT, src_stat.st_mode) works with S_IFREG included
+        // (libuv's uv_fs_copyfile does exactly that). openat2, which HostFs
+        // resolves through, instead rejects a nonzero mode on a non-creating
+        // open and unknown mode bits with EINVAL, so apply the kernel's
+        // open(2) rule before any filesystem sees it.
         let mode = if flags & libc::O_CREAT != 0 || flags & libc::O_TMPFILE == libc::O_TMPFILE {
-            mode
+            mode & 0o7777
         } else {
             0
         };

--- a/testing/conformance/fs/create-mode-type-bits.c
+++ b/testing/conformance/fs/create-mode-type-bits.c
@@ -1,0 +1,28 @@
+// RUN: %cc %s -o %t && rm -f %t.file && %runner %t %t.file
+//
+// open(2) masks the mode of a creating open to the permission bits, so the
+// common idiom open(dst, O_CREAT, src_stat.st_mode) works even though the
+// source's st_mode carries file-type bits (S_IFREG | 0644 = 0100644).
+// libuv's uv_fs_copyfile opens the destination exactly that way, so a
+// runtime that resolves opens through a stricter interface — openat2
+// rejects unknown mode bits with EINVAL — must apply the kernel's masking
+// itself or node's fs.copyFileSync (and everything above it, fs-extra,
+// create-react-app) fails where the kernel succeeds. The created file's
+// permission bits must equal the mode with the type bits stripped, less
+// the umask, matching native behavior.
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    if (argc != 2) return 10;
+    umask(022);
+    int fd = open(argv[1], O_CREAT | O_TRUNC | O_WRONLY, S_IFREG | 0644);
+    if (fd < 0) return 11;
+    struct stat st;
+    if (fstat(fd, &st) != 0) return 12;
+    if ((st.st_mode & 07777) != 0644) return 13;
+    if (close(fd) != 0) return 14;
+    return 0;
+}


### PR DESCRIPTION
libuv's uv_fs_copyfile opens the copy destination with the source's full
st_mode — S_IFREG | 0644 = 0100644, file-type bits included. That is legal
for open(2), which ignores everything outside the permission bits, but the
personality resolves guest opens through openat2(RESOLVE_IN_ROOT), and
openat2 validates its arguments strictly: unknown mode bits are EINVAL. Any
open(dst, O_CREAT, src_stat.st_mode) — a common idiom well beyond libuv —
therefore failed under Chimera while succeeding natively. Node's
fs.copyFileSync returned EINVAL, which broke fs-extra's copySync and
aborted npx create-react-app during its template copy.

Personality::open already normalizes the other side of this strict-
interface mismatch: it zeroes the mode of a non-creating open and strips
the extra flags from an O_PATH open. Extend the same open(2) rule to the
mode of a creating open by masking it to 0o7777 before any filesystem sees
it, exactly as the kernel's open does. The neighboring mutators need no
change: mkdir forwards to the host's mkdir(2), which itself ignores
file-type bits, and mknod's mode legitimately carries the type.

A new conformance test, fs/create-mode-type-bits.c, creates a file with
mode S_IFREG | 0644 and asserts the open succeeds and the file carries
permission bits 0644; it fails under Chimera without this patch. Both
`make conformance` and `make conformance-native` pass all 153 tests, and
`node -e 'require("fs").copyFileSync("/etc/os-release","/tmp/x")'`
succeeds under both the default and --unsafe routes.
