### PR TITLE
runtime: serve stats over a clean delta with one host syscall

### DIFF
--- a/runtime/sys/linux/delta.rs
+++ b/runtime/sys/linux/delta.rs
@@ -17,6 +17,10 @@
 //! `user.chimera.origin`. The delta must therefore sit on a filesystem with
 //! user xattrs (ext4, XFS, btrfs, tmpfs); [`Delta::open`] probes for them and
 //! refuses at startup rather than failing at the first unlink.
+//!
+//! `<delta>/taint` is one byte that says whether `data/` has ever held an
+//! entry, mapped `MAP_SHARED` by every process over the delta so cleanliness
+//! is a memory load, not a probe. See [`Delta::is_clean`].
 
 use std::{
     ffi::{CStr, CString},
@@ -25,7 +29,7 @@ use std::{
         unix::ffi::OsStrExt,
     },
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicU8, AtomicU64, Ordering},
 };
 
 use super::vfs::Errno;
@@ -49,6 +53,81 @@ pub struct Delta {
     /// Distinguishes concurrent stagings within one process; the pid in the
     /// staging name keeps forked processes apart.
     staging_seq: AtomicU64,
+    taint: TaintFlag,
+}
+
+/// One shared byte that says whether the upper tree has ever held an entry:
+/// a `MAP_SHARED` mapping of the `<delta>/taint` file, so every process over
+/// the delta — forked guest processes and concurrent sessions alike — reads
+/// the same page-cache byte with a plain load, no syscall. Monotonic: set
+/// before a first mutation publishes, never cleared.
+struct TaintFlag {
+    byte: std::ptr::NonNull<AtomicU8>,
+}
+
+// The mapping is plain shared memory accessed through an atomic.
+unsafe impl Send for TaintFlag {}
+unsafe impl Sync for TaintFlag {}
+
+impl TaintFlag {
+    /// Failure refuses the delta: a session without the mapping could write
+    /// upper entries with `taint` a no-op, while sessions that did map the
+    /// byte keep trusting a cleanliness the writes have falsified.
+    fn open(path: &Path) -> Result<TaintFlag, Errno> {
+        let cpath = cpath(path)?;
+        // O_NOFOLLOW, and the inode is validated before the ftruncate below:
+        // in a crafted delta the name could be a symlink to (or a hard link
+        // of) any writable file, and truncating through it would corrupt the
+        // target. Only what this format creates — a private one-byte regular
+        // file — is accepted.
+        let fd = unsafe {
+            libc::open(
+                cpath.as_ptr(),
+                libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o644,
+            )
+        };
+        if fd < 0 {
+            return Err(last_errno());
+        }
+        let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+        let mut st: libc::stat = unsafe { std::mem::zeroed() };
+        if unsafe { libc::fstat(fd.as_raw_fd(), &mut st) } < 0 {
+            return Err(last_errno());
+        }
+        if st.st_mode & libc::S_IFMT != libc::S_IFREG || st.st_nlink != 1 || st.st_size > 1 {
+            return Err(Errno::EINVAL);
+        }
+        if unsafe { libc::ftruncate(fd.as_raw_fd(), 1) } < 0 {
+            return Err(last_errno());
+        }
+        let ptr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                1,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED,
+                fd.as_raw_fd(),
+                0,
+            )
+        };
+        if ptr == libc::MAP_FAILED {
+            return Err(last_errno());
+        }
+        Ok(TaintFlag {
+            byte: std::ptr::NonNull::new(ptr as *mut AtomicU8).ok_or(Errno::EINVAL)?,
+        })
+    }
+
+    fn get(&self) -> &AtomicU8 {
+        unsafe { self.byte.as_ref() }
+    }
+}
+
+impl Drop for TaintFlag {
+    fn drop(&mut self) {
+        unsafe { libc::munmap(self.byte.as_ptr() as *mut libc::c_void, 1) };
+    }
 }
 
 impl Delta {
@@ -59,15 +138,46 @@ impl Delta {
     /// xattrs.
     pub fn open(root: impl Into<PathBuf>) -> Result<Self, Errno> {
         let root = root.into();
+        let data = root.join("data");
+        let tmp = root.join("tmp");
+        std::fs::create_dir_all(&data).map_err(|e| Errno::from_io(&e))?;
+        std::fs::create_dir_all(&tmp).map_err(|e| Errno::from_io(&e))?;
         let delta = Self {
-            data: root.join("data"),
-            tmp: root.join("tmp"),
+            data,
+            tmp,
             staging_seq: AtomicU64::new(0),
+            taint: TaintFlag::open(&root.join("taint"))?,
         };
-        std::fs::create_dir_all(&delta.data).map_err(|e| Errno::from_io(&e))?;
-        std::fs::create_dir_all(&delta.tmp).map_err(|e| Errno::from_io(&e))?;
         delta.probe_xattrs()?;
+        // A reattach may find upper state the flag file predates (a delta
+        // from before the flag existed, or a branch copy that carried only
+        // `data/`): entries in the tree, or a mutation to the root itself,
+        // whose claimed identity (origin) or opacity is bookkeeping on
+        // `data/` with no child entry to betray it. Taint by inspection so
+        // cleanliness always implies an untouched upper; inspection errors
+        // read as tainted.
+        let root_claimed = origin(&delta.data).map_or(true, |o| o.is_some())
+            || is_opaque(&delta.data).unwrap_or(true);
+        match std::fs::read_dir(&delta.data).map(|mut entries| entries.next()) {
+            Ok(None) if !root_claimed => {}
+            _ => delta.taint(),
+        }
         Ok(delta)
+    }
+
+    /// Whether the upper tree has never held an entry. While clean, the
+    /// merged view is the lower verbatim — no shadow, no whiteout, no opaque
+    /// marker can exist, whatever path a symlink expansion takes — which is
+    /// what licenses the overlay's one-syscall stat. The mutators taint
+    /// before their first write publishes; the taint byte's store retires
+    /// before the publishing syscall enters the kernel, so a reader that
+    /// still observes a clean flag also observes the upper without the entry.
+    pub fn is_clean(&self) -> bool {
+        self.taint.get().load(Ordering::Acquire) == 0
+    }
+
+    fn taint(&self) {
+        self.taint.get().store(1, Ordering::Release);
     }
 
     /// The upper file backing a mount-relative guest path.
@@ -118,6 +228,11 @@ impl Delta {
     /// Parents materialize lazily — only when something lands beneath them —
     /// so an untouched subtree leaves no trace in the delta.
     pub fn materialize_parents(&self, rel: &Path) -> Result<(), Errno> {
+        // Every first entry a clean delta gains — a create's parents, a
+        // whiteout, a copy-up — passes through here (or through `scaffold`/
+        // `copy_up_dir`) before it publishes; the remaining mutators only
+        // ever touch upper state that already exists.
+        self.taint();
         if let Some(parent) = self.data_path(rel).parent() {
             std::fs::create_dir_all(parent).map_err(|e| Errno::from_io(&e))?;
         }
@@ -129,6 +244,7 @@ impl Delta {
     /// identity. A scaffold carries no origin, which is what keeps stat
     /// serving the lower directory it merges with.
     pub fn scaffold(&self, rel: &Path) -> Result<(), Errno> {
+        self.taint();
         std::fs::create_dir_all(self.data_path(rel)).map_err(|e| Errno::from_io(&e))
     }
 
@@ -138,6 +254,7 @@ impl Delta {
     /// lands last, so an interruption leaves ordinary scaffolding — which
     /// keeps serving the lower — never a half-claimed directory.
     pub fn copy_up_dir(&self, src: &Path, rel: &Path) -> Result<(), Errno> {
+        self.taint();
         let csrc = cpath(src)?;
         let mut st: libc::stat = unsafe { std::mem::zeroed() };
         check(unsafe { libc::stat(csrc.as_ptr(), &mut st) })?;
@@ -769,6 +886,61 @@ mod tests {
         assert!(scratch.join("delta/tmp").is_dir());
         // Reopening an existing delta is how attach and fork see it.
         assert!(Delta::open(scratch.join("delta")).is_ok());
+    }
+
+    /// A mutation aimed at the root itself leaves `data/` without a single
+    /// child entry — its whole record is bookkeeping on the directory. A
+    /// branch copy carries `data/` but not the taint file, so the attach
+    /// inspection must read the root's claim, not just its entries.
+    #[test]
+    fn reattach_reads_a_claimed_root_as_tainted() {
+        let scratch = Scratch::new();
+        let Some(d) = delta(&scratch) else { return };
+        assert!(d.is_clean());
+
+        let data = scratch.join("delta/data");
+        let cdata = cpath(&data).unwrap();
+        let mut st: libc::stat = unsafe { std::mem::zeroed() };
+        assert_eq!(unsafe { libc::stat(cdata.as_ptr(), &mut st) }, 0);
+        record_origin(&data, &Origin::of(&st)).unwrap();
+        drop(d);
+        std::fs::remove_file(scratch.join("delta/taint")).unwrap();
+
+        let reattached = Delta::open(scratch.join("delta")).unwrap();
+        assert!(!reattached.is_clean());
+    }
+
+    /// Without the shared byte a session's `taint` would be a no-op while
+    /// other sessions keep trusting the zero they mapped; such a delta is
+    /// refused, like one whose filesystem cannot carry the xattrs.
+    #[test]
+    fn open_refuses_an_unmappable_taint_flag() {
+        let scratch = Scratch::new();
+        let Some(_) = delta(&scratch) else { return };
+        std::fs::remove_file(scratch.join("delta/taint")).unwrap();
+        std::fs::create_dir(scratch.join("delta/taint")).unwrap();
+        assert!(Delta::open(scratch.join("delta")).is_err());
+    }
+
+    /// In a crafted delta the taint name may lead elsewhere — a symlink to,
+    /// or a hard link of, a writable file. Opening must not follow it, and
+    /// the truncate-to-one-byte must never reach the foreign inode.
+    #[test]
+    fn open_refuses_a_planted_taint_flag() {
+        let scratch = Scratch::new();
+        let Some(_) = delta(&scratch) else { return };
+        let victim = scratch.join("victim");
+        std::fs::write(&victim, b"do not truncate").unwrap();
+
+        std::fs::remove_file(scratch.join("delta/taint")).unwrap();
+        std::os::unix::fs::symlink(&victim, scratch.join("delta/taint")).unwrap();
+        assert!(Delta::open(scratch.join("delta")).is_err());
+        assert_eq!(std::fs::read(&victim).unwrap(), b"do not truncate");
+
+        std::fs::remove_file(scratch.join("delta/taint")).unwrap();
+        std::fs::hard_link(&victim, scratch.join("delta/taint")).unwrap();
+        assert!(Delta::open(scratch.join("delta")).is_err());
+        assert_eq!(std::fs::read(&victim).unwrap(), b"do not truncate");
     }
 
     #[test]

--- a/runtime/sys/linux/namespace.rs
+++ b/runtime/sys/linux/namespace.rs
@@ -112,15 +112,17 @@ impl Namespace {
             // walk, the normalized path is the canonical one. Anything the
             // proof cannot cover — a symlink, a missing component, a
             // shadowed prefix — walks below.
-            let norm = normalize(path);
-            if let Some(st) = m.fs.resolve_fast(&norm) {
-                return Ok(Resolved {
-                    fs: Arc::clone(&m.fs),
-                    rel: norm.clone(),
-                    writable: !m.flags.rdonly,
-                    abs: norm,
-                    stat: Some(st),
-                });
+            if normalizes_exactly(path) {
+                let norm = normalize(path);
+                if let Some(st) = m.fs.resolve_fast(&norm) {
+                    return Ok(Resolved {
+                        fs: Arc::clone(&m.fs),
+                        rel: norm.clone(),
+                        writable: !m.flags.rdonly,
+                        abs: norm,
+                        stat: Some(st),
+                    });
+                }
             }
         }
 
@@ -134,6 +136,7 @@ impl Namespace {
                 Part::Dot => continue,
                 Part::DotDot => {
                     acc.pop(); // popping at `/` stays at `/` — confined
+                    last = None; // the remembered stat named the popped child
                     continue;
                 }
                 Part::Name(name) => name,
@@ -189,9 +192,17 @@ impl Namespace {
             if m.fs.confines() {
                 return m.fs.stat(path, follow);
             }
+            // The raw path, not the normalized one: the whole-path fast path
+            // resolves with kernel semantics, where `..` acts on the
+            // symlink-expanded chain, which lexical normalization cannot know.
+            if let Some(r) = m.fs.stat_fast(path, follow) {
+                return r;
+            }
             // The follow flag is moot on the fast path: it proved no symlink
             // participates, final component included.
-            if let Some(st) = m.fs.resolve_fast(&normalize(path)) {
+            if normalizes_exactly(path)
+                && let Some(st) = m.fs.resolve_fast(&normalize(path))
+            {
                 return Ok(st);
             }
         }
@@ -256,6 +267,15 @@ pub fn normalize(path: &Path) -> PathBuf {
         }
     }
     out
+}
+
+/// Whether [`normalize`] preserves the path's meaning. Removing `..`
+/// lexically assumes the component before it is a real directory, but a
+/// symlink there makes `..` act on the expanded target — and which
+/// components are symlinks is exactly what the lexical fast paths do not
+/// know, so a `..` anywhere sends the path to the walk.
+fn normalizes_exactly(path: &Path) -> bool {
+    !path.components().any(|c| matches!(c, Component::ParentDir))
 }
 
 #[cfg(test)]

--- a/runtime/sys/linux/overlayfs.rs
+++ b/runtime/sys/linux/overlayfs.rs
@@ -683,6 +683,11 @@ impl Vfs for OverlayFs {
     }
 
     fn resolve_fast(&self, path: &Path) -> Option<Stat> {
+        // A clean delta serves everything from the lower, so the upper walk
+        // has nothing to say and the lower's own proof suffices.
+        if self.inner.delta.is_clean() {
+            return self.inner.lower.resolve_fast(path);
+        }
         // Only a pure-lower path can skip the merge. The upper walk stops at
         // the first missing component — one lstat on the common no-shadow
         // prefix — and the lower then proves no symlink participates, which
@@ -691,6 +696,18 @@ impl Vfs for OverlayFs {
             Ok(Visibility::Lower) => self.inner.lower.resolve_fast(path),
             _ => None,
         }
+    }
+
+    fn stat_fast(&self, path: &Path, follow: bool) -> Option<Result<Stat, Errno>> {
+        // While the delta is clean the merged view is the lower verbatim —
+        // whatever path a symlink expansion takes, there is no upper entry
+        // for it to land on — so the question passes wholesale to the lower.
+        // The lower must answer for itself: this delta's cleanliness says
+        // nothing about, say, a nested overlay's own upper.
+        if !self.inner.delta.is_clean() {
+            return None;
+        }
+        self.inner.lower.stat_fast(path, follow)
     }
 
     fn host_path(&self, path: &Path) -> Option<PathBuf> {
@@ -1612,6 +1629,172 @@ mod tests {
         let direct = ns.stat_path(Path::new("/real/g"), true).unwrap();
         assert_eq!(via_link.ino, direct.ino);
         assert_eq!(via_link.size, 7); // "upper-g", not "lower-g"'s identity
+    }
+
+    /// While the delta is clean, `stat_fast` answers everything the lower
+    /// answers — symlink chains and misses included, which `resolve_fast`
+    /// must decline — and the first upper mutation silences it for good.
+    #[test]
+    fn stat_fast_serves_only_clean_deltas() {
+        let scratch = Scratch::new();
+        let Some((fs, _delta)) = overlay(&scratch) else {
+            return;
+        };
+        std::fs::create_dir_all(scratch.join("lower/d")).unwrap();
+        std::fs::write(scratch.join("lower/d/f"), b"x").unwrap();
+        std::os::unix::fs::symlink("d", scratch.join("lower/link")).unwrap();
+
+        let st = fs.stat_fast(Path::new("/d/f"), true).unwrap().unwrap();
+        assert_eq!(st.file_type, FileType::Regular);
+        let via_link = fs.stat_fast(Path::new("/link/f"), true).unwrap().unwrap();
+        assert_eq!(via_link.ino, st.ino);
+        let l = fs.stat_fast(Path::new("/link"), false).unwrap().unwrap();
+        assert_eq!(l.file_type, FileType::Symlink);
+        assert_eq!(
+            fs.stat_fast(Path::new("/absent"), true)
+                .unwrap()
+                .unwrap_err(),
+            Errno::ENOENT
+        );
+
+        fs.chmod(Path::new("/d/f"), true, Mode(0o600)).unwrap();
+        assert!(fs.stat_fast(Path::new("/d/f"), true).is_none());
+        assert!(fs.stat_fast(Path::new("/link/f"), true).is_none());
+    }
+
+    /// A mutation aimed at the root leaves no child entry in the upper —
+    /// its whole record is the claim on `data/` itself — and must silence
+    /// the fast path like any other write.
+    #[test]
+    fn root_mutation_taints() {
+        let scratch = Scratch::new();
+        let Some((fs, _delta)) = overlay(&scratch) else {
+            return;
+        };
+        std::fs::write(scratch.join("lower/f"), b"x").unwrap();
+        assert!(fs.stat_fast(Path::new("/f"), true).is_some());
+
+        fs.chmod(Path::new("/"), true, Mode(0o711)).unwrap();
+        assert!(fs.stat_fast(Path::new("/f"), true).is_none());
+        assert!(fs.stat_fast(Path::new("/"), true).is_none());
+    }
+
+    /// The taint is a property of the delta on disk, not of one `Delta`
+    /// instance: a mutation through any handle — another host process of the
+    /// guest tree, a concurrent session — is seen by every other, and a
+    /// reattach of a non-empty delta starts tainted.
+    #[test]
+    fn taint_is_shared_across_delta_handles() {
+        let scratch = Scratch::new();
+        let Some((fs, delta)) = overlay(&scratch) else {
+            return;
+        };
+        std::fs::write(scratch.join("lower/f"), b"x").unwrap();
+        assert!(fs.stat_fast(Path::new("/f"), true).is_some());
+
+        // The sibling handle mutates; this overlay must stop answering
+        // before the whiteout could bleed a stale lower hit.
+        delta.whiteout(Path::new("/f")).unwrap();
+        assert!(fs.stat_fast(Path::new("/f"), true).is_none());
+
+        let reattached = Delta::open(scratch.join("delta")).unwrap();
+        assert!(!reattached.is_clean());
+    }
+
+    /// `..` after a symlink acts on the expanded target, which no lexical
+    /// fast path can know: with `/link -> dir/sub`, `/link/../file` names
+    /// `/dir/file`, never `/file`. The whole-path stat must see the raw
+    /// path so the kernel applies that order, and the walked path must
+    /// agree — clean and tainted alike.
+    #[test]
+    fn stat_path_orders_dotdot_after_symlinks() {
+        use super::super::namespace::{MountFlags, Namespace};
+
+        let scratch = Scratch::new();
+        let Some((fs, _delta)) = overlay(&scratch) else {
+            return;
+        };
+        std::fs::create_dir_all(scratch.join("lower/dir/sub")).unwrap();
+        std::fs::write(scratch.join("lower/dir/file"), b"in-dir").unwrap();
+        std::fs::write(scratch.join("lower/file"), b"at-root").unwrap();
+        std::os::unix::fs::symlink("dir/sub", scratch.join("lower/link")).unwrap();
+
+        let ns = Namespace::with_root(
+            Arc::new(OverlayFs {
+                inner: Arc::clone(&fs.inner),
+            }),
+            MountFlags::NONE,
+        );
+        let direct = ns.stat_path(Path::new("/dir/file"), true).unwrap();
+        let clean = ns.stat_path(Path::new("/link/../file"), true).unwrap();
+        assert_eq!(clean.ino, direct.ino);
+        let dir = ns.stat_path(Path::new("/dir"), true).unwrap();
+        let popped = ns.stat_path(Path::new("/dir/sub/.."), true).unwrap();
+        assert_eq!(popped.ino, dir.ino);
+
+        ns.stat_path(Path::new("/absent"), true).unwrap_err();
+        // Tainting sends the path to the walk, which must agree; the chmod
+        // copied the file up, so compare against the merged view it serves
+        // now, not the lower inode it left behind.
+        fs.chmod(Path::new("/dir/file"), true, Mode(0o600)).unwrap();
+        let walked = ns.stat_path(Path::new("/link/../file"), true).unwrap();
+        let merged = ns.stat_path(Path::new("/dir/file"), true).unwrap();
+        assert_eq!(walked.ino, merged.ino);
+        assert_eq!(walked.mode.0 & 0o7777, 0o600);
+
+        // A trailing `..` names the parent, never the child the walk just
+        // popped — through a symlink expansion too.
+        let popped = ns.stat_path(Path::new("/dir/sub/.."), true).unwrap();
+        assert_eq!(popped.ino, dir.ino);
+        let via_link = ns.stat_path(Path::new("/link/.."), true).unwrap();
+        assert_eq!(via_link.ino, dir.ino);
+    }
+
+    /// A clean delta only proves its own layer transparent; the lower must
+    /// answer for itself. A nested overlay whose delta shadows the target of
+    /// a lower symlink declines the whole-path stat, and the walk finds the
+    /// inner upper entry.
+    #[test]
+    fn stat_fast_defers_to_a_layered_lower() {
+        use super::super::namespace::{MountFlags, Namespace};
+
+        let scratch = Scratch::new();
+        std::fs::create_dir_all(scratch.join("lower/real")).unwrap();
+        std::fs::write(scratch.join("lower/real/g"), b"lower-g").unwrap();
+        std::os::unix::fs::symlink("real", scratch.join("lower/link")).unwrap();
+        let host = Arc::new(HostFs::new(scratch.join("lower")).unwrap());
+        let inner = match OverlayFs::new(host, scratch.join("delta-inner")) {
+            Ok(fs) => Arc::new(fs),
+            Err(Errno(libc::ENOTSUP)) => return,
+            Err(e) => panic!("inner overlay: {e:?}"),
+        };
+        let outer = OverlayFs::new(
+            Arc::clone(&inner) as Arc<dyn Vfs>,
+            scratch.join("delta-outer"),
+        )
+        .unwrap();
+
+        // Clean all the way down: the chain answers wholesale.
+        let st = outer
+            .stat_fast(Path::new("/link/g"), true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(st.size, 7);
+
+        // The inner overlay shadows the symlink's target; the outer delta is
+        // still clean, but the answer is no longer the host's.
+        inner
+            .chmod(Path::new("/real/g"), true, Mode(0o600))
+            .unwrap();
+        assert!(outer.stat_fast(Path::new("/link/g"), true).is_none());
+        let ns = Namespace::with_root(
+            Arc::new(OverlayFs {
+                inner: Arc::clone(&outer.inner),
+            }),
+            MountFlags::NONE,
+        );
+        let walked = ns.stat_path(Path::new("/link/g"), true).unwrap();
+        assert_eq!(walked.mode.0 & 0o7777, 0o600);
     }
 
     #[test]

--- a/runtime/sys/linux/vfs.rs
+++ b/runtime/sys/linux/vfs.rs
@@ -124,6 +124,21 @@ pub trait Vfs: Send + Sync {
         None
     }
 
+    /// Answer `stat`/`lstat` for a raw absolute path wholesale, with kernel
+    /// resolution semantics — symlinks followed and `..` applied to the
+    /// expanded chain, the final symlink per `follow` — when the filesystem
+    /// can prove that resolution is its whole answer. `Some` is
+    /// authoritative, errors included; `None` sends the caller to the walk.
+    /// Unlike [`Vfs::resolve_fast`] this makes no claim that the path
+    /// lexically names the object, so it serves only stat lookups, never a
+    /// resolution whose path a later operation acts on. A confining
+    /// filesystem resolves whole paths itself by definition; a layered one
+    /// must prove its own layer transparent *and* delegate below, since its
+    /// composed view is only as resolvable as its parts.
+    fn stat_fast(&self, path: &Path, follow: bool) -> Option<Result<Stat, Errno>> {
+        self.confines().then(|| self.stat(path, follow))
+    }
+
     /// The host path backing a mount-relative path, if this filesystem is host
     /// passthrough. The runtime uses it to load an `execve` target through its
     /// ELF loader without reaching back through this trait byte by byte; a


### PR DESCRIPTION
A guest stat under the default branch filesystem cost 4 host syscalls
and ran 4.2x native (4149 ns/op against 989 in perf/fs, versus 1.5x for
a --cache 60 FUSE mount of the same view): the overlay probed the delta
for an upper entry with a statx that returned ENOENT on every call, and
the lower resolve then paid the openat2(O_PATH) + fstatat + close
triple, whose openat2 exists only to confine the walk and prove no
symlink participates. The kernel offers no way to combine that proof
with the stat itself, so the triple cannot shrink — but the proof is
only needed at all because a lower symlink expansion could land on a
path the upper shadows. While the upper holds nothing, the merged view
is the lower verbatim, whatever paths symlinks take, and a plain
fstatat is the whole answer.

Record that one fact in the delta: `<delta>/taint`, a byte every
process over the delta maps MAP_SHARED, so forked guest processes and
concurrent sessions (the tree-wide flock is shared) all observe it with
a memory load and no syscall. It is monotonic — set before a first
upper mutation publishes, never cleared — and every way a clean delta
gains its first entry funnels through materialize_parents, scaffold, or
copy_up_dir, which set it; the remaining mutators only touch upper
state that already exists. A reattach taints by inspecting data/, so a
delta from before the flag existed (or a branch copy carrying only
data/) is never trusted clean.

While the delta is clean, the overlay's new Vfs::stat_fast answers
Namespace::stat_path with the lower's stat — one fstatat against the
host root, kernel resolution semantics, errors authoritative — and
resolve_fast skips the visibility walk for the lower's own proof,
dropping open resolution from 4 syscalls to 3. stat_fast deliberately
makes no claim that the lexical path names the object, so it serves
only stat lookups, never a resolution whose path a later operation acts
on; the first upper mutation silences it for good and every path falls
back to the visibility walk unchanged.

perf/fs (release, 20k iters x 5 rounds, /usr/lib/os-release): stat
4149 -> 1549 ns/op, 4.2x -> 1.5x native, level with the cached FUSE
mount but with no staleness window; open 11201 -> 9609. An strace of
the stat loop confirms exactly one newfstatat per guest stat. Covered
by new overlay tests for the clean fast path (symlink chains and
misses included), taint sharing across handles, and tainted reattach;
the conformance suite passes 155/155 in the default, --unsafe, and
native modes.
