### PR TITLE
runtime: skip whiteout probes on shapes that cannot carry one

### DIFF
--- a/runtime/sys/linux/delta.rs
+++ b/runtime/sys/linux/delta.rs
@@ -404,6 +404,14 @@ fn rename_exchange(a: &Path, b: &Path) -> Result<(), Errno> {
     })
 }
 
+/// Whether an entry with this metadata could be a whiteout at all: a
+/// whiteout is always an *empty* regular file — built by
+/// [`Delta::stage_whiteout`] and never written — so a file with bytes in it,
+/// and every other type, provably carries no marker and needs no xattr read.
+pub fn may_be_whiteout(md: &std::fs::Metadata) -> bool {
+    md.is_file() && md.len() == 0
+}
+
 /// `true` when the upper entry at `path` is a whiteout. A missing entry is
 /// not one, and a filesystem answer of "no such attribute" (or no xattrs at
 /// all) is an ordinary upper file.

--- a/runtime/sys/linux/overlayfs.rs
+++ b/runtime/sys/linux/overlayfs.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use super::{
-    delta::{Delta, is_opaque, is_whiteout, is_whiteout_fd, mark_opaque, origin},
+    delta::{Delta, is_opaque, is_whiteout, is_whiteout_fd, mark_opaque, may_be_whiteout, origin},
     hostfs::HostFs,
     vfs::{
         DirEntry, Errno, File, FileType, Mode, OpenFlags, RenameFlags, Stat, StatFs, Timespec, Vfs,
@@ -114,7 +114,7 @@ impl OverlayInner {
                 }
                 Err(e) => return Err(Errno::from_io(&e)),
             };
-            if is_whiteout(&cur)? {
+            if may_be_whiteout(&md) && is_whiteout(&cur)? {
                 // The name is deleted; nothing below it survives either.
                 return Ok(if is_final {
                     Visibility::Whiteout
@@ -569,7 +569,11 @@ impl Vfs for OverlayFs {
         let to_upper = inner.delta.data_path(to);
         let mut removed_marker = false;
         match std::fs::symlink_metadata(&to_upper) {
-            Ok(_) if is_whiteout(&to_upper)? && (src_dir || flags.noreplace()) => {
+            Ok(md)
+                if may_be_whiteout(&md)
+                    && is_whiteout(&to_upper)?
+                    && (src_dir || flags.noreplace()) =>
+            {
                 inner.remove_marker(to)?;
                 removed_marker = true;
             }
@@ -894,7 +898,8 @@ impl File for OverlayDir {
         // appears.
         let mut shadowed: HashSet<OsString> = HashSet::new();
         for e in self.upper.getdents()? {
-            let whiteout = is_whiteout(&self.upper_host.join(&e.name))?;
+            let whiteout =
+                e.file_type == FileType::Regular && is_whiteout(&self.upper_host.join(&e.name))?;
             shadowed.insert(e.name.clone());
             if !whiteout {
                 out.push(e);


### PR DESCRIPTION
The overlay visibility walk asked is_whiteout — a full-path lgetxattr
the kernel re-walks from the root — on every upper component of every
path, and the merged-listing fold asked it once per upper entry. On a
create-heavy workload (200 file creates plus one recursive listing
under a 5-deep working directory) that came to 39.3k lgetxattr calls,
every one of them a miss, two thirds of the walk's syscall budget spent
asking a question whose answer was already in hand: the walk stats each
component before probing it, and a whiteout is by construction an
*empty regular file* — built by Delta::stage_whiteout, never written —
so a directory, a symlink, or a file with bytes in it provably carries
no marker at all.

may_be_whiteout encodes that shape test in delta.rs next to the format
it follows from, and the probe sites consult the metadata they already
hold: the visibility walk and the rename-destination check guard the
lgetxattr with the stat's shape, and the merged-listing fold skips every
non-regular entry (the host layer resolves DT_UNKNOWN with a stat, so
the listed type is exact). Should a name race to some other inode
between the stat and the probe, the walk's answer is the same snapshot
it always was — the stat-then-getxattr sequence was never atomic.

On the same workload lgetxattr drops from 39.3k to 20.8k (the remainder
is the opaque probes on intermediate directories, a separate change).
Unit tests pass and the conformance suite passes 155/155 in both the
default and --unsafe modes.
